### PR TITLE
No warnings

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -67,11 +67,15 @@ module EventMachine
   class HttpChunkHeader < Hash
     # When parsing chunked encodings this is set
     attr_accessor :http_chunk_size
+    
+    def initialize
+      super
+      @http_chunk_size = '0'
+    end
 
     # Size of the chunk as an integer
     def chunk_size
-      return @chunk_size unless @chunk_size.nil?
-      @chunk_size = @http_chunk_size ? @http_chunk_size.to_i(base=16) : 0
+      @http_chunk_size.to_i(base=16)
     end
   end
 
@@ -242,6 +246,7 @@ module EventMachine
       @redirects = 0
       @response = ''
       @error = ''
+      @headers = nil
       @last_effective_url = nil
       @content_decoder = nil
       @stream = nil


### PR DESCRIPTION
Retry from http://github.com/igrigorik/em-http-request/issues/issue/56

Caching the computed integer version of @http_chunk_size in @chunk_size was a premature optimization since chunk_size is only called once per chunk.  I got rid of the extra variable.

For the @headers, I simply pre-initialized the value to nil.
