### PR TITLE
Encoding finder bug

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -652,7 +652,9 @@ module EventMachine
       end
 
       if ''.respond_to?(:force_encoding) && /;\s*charset=\s*(.+?)\s*(;|$)/.match(response_header[CONTENT_TYPE])
-        @content_charset = Encoding.find $1
+        encoding = $1.to_s.dup
+        encoding.gsub!(/\"/, '')
+        @content_charset = Encoding.find encoding
       end
 
       true


### PR DESCRIPTION
I came across an issue when a site's CONTENT_TYPE was coming back as "\"ISO-8859-1\"". The "Content.find" was choking on it when it should have been able to find the ISO-8859-1 encoding. 

This small bit fixes this issue. 
