### PR TITLE
Named connections for EM::MultiRequest (em-synchrony style)

### DIFF
--- a/spec/multi_spec.rb
+++ b/spec/multi_spec.rb
@@ -3,39 +3,94 @@ require 'stallion'
 
 describe EventMachine::MultiRequest do
 
+  let(:multi) { EventMachine::MultiRequest.new }
+  let(:url)   { 'http://127.0.0.1:8090/' }
+
   it "should submit multiple requests in parallel and return once all of them are complete" do
     EventMachine.run {
+      multi.add :a, EventMachine::HttpRequest.new(url).get
+      multi.add :b, EventMachine::HttpRequest.new(url).post
+      multi.add :c, EventMachine::HttpRequest.new(url).head
+      multi.add :d, EventMachine::HttpRequest.new(url).delete
+      multi.add :e, EventMachine::HttpRequest.new(url).put
 
-      # create an instance of multi-request handler, and the requests themselves
-      multi = EventMachine::MultiRequest.new
-
-      # add multiple requests to the multi-handler
-      multi.add(EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get(:query => {:q => 'test'}))
-      multi.add(EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get)
-
-      multi.callback  {
-        multi.responses[:succeeded].size.should == 2
-        multi.responses[:succeeded][0].response.should match(/test|Hello/)
-        multi.responses[:succeeded][1].response.should match(/test|Hello/)
+      multi.callback {
+        multi.responses[:callback].size.should == 5
+        multi.responses[:callback].each { |name, response|
+          [ :a, :b, :c, :d, :e ].should include(name)
+          response.response_header.status.should == 200
+        }
+        multi.responses[:errback].size.should == 0
 
         EventMachine.stop
       }
     }
   end
 
-  it "should accept multiple open connections and return once all of them are complete" do
-    EventMachine.run {
-      http1 = EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get(:query => {:q => 'test'})
-      http2 = EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get
+  describe "#requests" do
+    it "should return the added requests" do
+      request1 = stub('request1', :callback => nil, :errback => nil)
+      request2 = stub('request2', :callback => nil, :errback => nil)
 
-      multi = EventMachine::MultiRequest.new([http1, http2]) do
-        multi.responses[:succeeded].size.should == 2
-        multi.responses[:succeeded][0].response.should match(/test|Hello/)
-        multi.responses[:succeeded][1].response.should match(/test|Hello/)
+      multi.add :a, request1
+      multi.add :b, request2
+
+      multi.requests.should == [ request1, request2 ]
+    end
+  end
+
+  describe "#responses" do
+    it "should have an empty :callback hash" do
+      multi.responses[:callback].should be_a(Hash)
+      multi.responses[:callback].size.should == 0
+    end
+
+    it "should have an empty :errback hash" do
+      multi.responses[:errback].should be_a(Hash)
+      multi.responses[:errback].size.should == 0
+    end
+
+    it "should provide access to the requests by name" do
+      EventMachine.run {
+        request1 = EventMachine::HttpRequest.new(url).get
+        request2 = EventMachine::HttpRequest.new(url).post
+        multi.add :a, request1
+        multi.add :b, request2
+
+        multi.callback {
+          multi.responses[:callback][:a].should equal(request1)
+          multi.responses[:callback][:b].should equal(request2)
+
+          EventMachine.stop
+        }
+      }
+    end
+  end
+
+  describe "#finished?" do
+    it "should be true when no requests have been added" do
+      multi.should be_finished
+    end
+
+    it "should be false while the requests are not finished" do
+      EventMachine.run {
+        multi.add :a, EventMachine::HttpRequest.new(url).get
+        multi.should_not be_finished
 
         EventMachine.stop
-      end
-    }
+      }
+    end
+
+    it "should be finished when all requests are finished" do
+      EventMachine.run {
+        multi.add :a, EventMachine::HttpRequest.new(url).get
+        multi.callback {
+          multi.should be_finished
+
+          EventMachine.stop
+        }
+      }
+    end
   end
 
 end


### PR DESCRIPTION
Here's a port of the em-synchrony interface for `MultiRequest` as discussed before (https://github.com/igrigorik/em-http-request/pull/91):
- provide the same signature for `#new`, `#add` and `#reponses` as em-synchrony
- provide a `#finished?` method
- warning: this is not backwards compatible to the current interface

I am wondering if we should continue to support the block style syntax; for now I have left it out as em-synchrony does not have it as well.

Let me know what needs to be changed before this can go in...

Cheers,
Martin
