### PR TITLE
Defer connection until needed

### DIFF
--- a/lib/em-http/request.rb
+++ b/lib/em-http/request.rb
@@ -3,35 +3,12 @@ module EventMachine
     @middleware = []
 
     def self.new(uri, options={})
-      begin
-        connopt = HttpConnectionOptions.new(uri, options)
+      connopt = HttpConnectionOptions.new(uri, options)
 
-        EventMachine.connect(connopt.host, connopt.port, HttpConnection) do |c|
-          c.connopts = connopt
-          c.uri = uri
-
-          c.pending_connect_timeout = connopt.connect_timeout
-          c.comm_inactivity_timeout = connopt.inactivity_timeout
-        end
-
-      rescue EventMachine::ConnectionError => e
-        #
-        # Currently, this can only fire on initial connection setup
-        # since #connect is a synchronous method. Hence, rescue the
-        # exception, and return a failed deferred which will immediately
-        # fail any client request.
-        #
-        # Once there is async-DNS, then we'll iterate over the outstanding
-        # client requests and fail them in order.
-        #
-        # Net outcome: failed connection will invoke the same ConnectionError
-        # message on the connection deferred, and on the client deferred.
-        #
-        conn = EventMachine::FailedConnection.new(uri, connopt)
-        conn.error = e.message
-        conn.fail
-        conn
-      end
+      c = HttpConnection.new
+      c.connopts = connopt
+      c.uri = uri
+      c
     end
 
     def self.use(klass, *args, &block)


### PR DESCRIPTION
Ok, so how about this as a first pass - passes all current specs and works with webmock (with another patch that I have on another branch but that's just some refactoring).

I'm not certain this would affect pipelining or keep-alive because it's very shallow in terms of modifications. It just defers the connection until the first http method is called against it.

Please let me know your thoughts. It probably needs some cleaning up/refactoring but I think this might just work for all without a huge complexity jump.

The one significant difference at this point is the removal of FailedConnection - this code would currently attempt a connection every time a method was called if the previous connection attempt failed. It's possible that we would want to add a @failed tracking variable much like @deferred - but that wouldn't be a huge addition to the codebase.
