### PR TITLE
Make automatic response decoding optional

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -257,7 +257,7 @@ module EventMachine
         @state = :body
       end
 
-      if !@req.no_decoding && decoder_class = HttpDecoders.decoder_for_encoding(response_header[CONTENT_ENCODING])
+      if @req.decoding && decoder_class = HttpDecoders.decoder_for_encoding(response_header[CONTENT_ENCODING])
         begin
           @content_decoder = decoder_class.new do |s| on_decoded_body_data(s) end
         rescue HttpDecoders::DecoderError

--- a/lib/em-http/http_client_options.rb
+++ b/lib/em-http/http_client_options.rb
@@ -1,7 +1,7 @@
 class HttpClientOptions
   attr_reader :uri, :method, :host, :port, :proxy
   attr_reader :headers, :file, :body, :query, :path
-  attr_reader :keepalive, :pass_cookies, :no_decoding
+  attr_reader :keepalive, :pass_cookies, :decoding
 
   attr_accessor :followed, :redirects
 
@@ -21,7 +21,7 @@ class HttpClientOptions
 
     @pass_cookies = options[:pass_cookies]
     @pass_cookies = true if @pass_cookies.nil?
-    @no_decoding = options[:no_decoding] || false
+    @decoding = options.fetch(:decoding, true)
 
     set_uri(uri)
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -329,7 +329,7 @@ describe EventMachine::HttpRequest do
 
       http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/gzip').get :head => {
         "accept-encoding" => "gzip, compressed"
-      }, :no_decoding => true
+      }, :decoding => false
 
       http.errback { failed(http) }
       http.callback {


### PR DESCRIPTION
In order for [em-net-http](https://github.com/igrigorik/em-http-request) to work transparently and be dropped into a project, it needs to disable the automatic response decoding.
