### PR TITLE
EventMachine::HttpStubConnection#unbind should allow no arguments e.g. reason=nil

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -25,7 +25,7 @@ module EventMachine
       @parent.connection_completed
     end
 
-    def unbind(reason)
+    def unbind(reason=nil)
       @parent.unbind(reason)
     end
   end


### PR DESCRIPTION
Creating a simple proxy app with goliath, I noticed after an HTTP request the server would crash with: https://gist.github.com/1074878, digging a bit and it looks like unbind should accept reason optionally.  The example server I wrote looks like this: https://gist.github.com/1074882
