### PR TITLE
http_reason should be 'unknown', not nil, on a non-standard HTTP response

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -208,7 +208,7 @@ module EventMachine
 
       @response_header.http_version = version.join('.')
       @response_header.http_status  = status
-      @response_header.http_reason  = CODE[status]
+      @response_header.http_reason  = CODE[status] || 'unknown'
 
       # invoke headers callback after full parse
       # if one is specified by the user

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -110,6 +110,19 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  it "should return HTTP reason 'unknown' on a non-standard status code" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/fail_with_nonstandard_response').get
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 420
+        http.response_header.http_reason.should == 'unknown'
+        EventMachine.stop
+      }
+    }
+  end
+
   it "should build query parameters from Hash" do
     EventMachine.run {
       http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get :query => {:q => 'test'}

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -74,6 +74,9 @@ Stallion.saddle :spec do |stable|
     if stable.request.path_info == '/fail'
       stable.response.status = 404
 
+    elsif stable.request.path_info == '/fail_with_nonstandard_response'
+      stable.response.status = 420
+
     elsif stable.request.query_string == 'q=test'
       stable.response.write 'test'
 
@@ -177,7 +180,7 @@ Stallion.saddle :spec do |stable|
       deflater.deflate("compressed")
       stable.response.write deflater.finish
       stable.response["Content-Encoding"] = "deflate"
-      
+
     elsif stable.request.env["HTTP_IF_NONE_MATCH"]
       stable.response.status = 304
 


### PR DESCRIPTION
The recent patch to add an http_reason meant non-standard response codes failed, as they are not in the CODE table. (For example, the twitter search API returns '420 Enhance your calm' when you are over-exuberant) This restores the 'unknown' response when there's a miss.
