### PR TITLE
Fixed error with OAuth middleware

### DIFF
--- a/lib/em-http/middleware/oauth.rb
+++ b/lib/em-http/middleware/oauth.rb
@@ -5,7 +5,10 @@ module EventMachine
 
     class OAuth
       def initialize(opts = {})
-        @opts = opts
+        @opts = opts.dup
+        # Allow both `oauth` gem and `simple_oauth` gem opts formats
+        @opts[:token] ||= @opts.delete(:access_token)
+        @opts[:token_secret] ||= @opts.delete(:access_token_secret)
       end
 
       def request(client, head, body)


### PR DESCRIPTION
`em-http-request (1.0.0.beta.4)` and `oauth (0.4.5)` do not work together.

The big problem is the `oauth` gem's `sign!` method is flawed.  It must maintain a list of popular clients and continuously update it's implementation when each client does.  This is obviously a bad situation.

I removed the `oauth` gem in favor of the `simple_oauth` gem.  The `simple_oauth` gem generates an `Authorization` header string.  It does not need to know how `em-http-request` is implemented at all - `em-http-request` just needs to pass it the correct arguments.
