### PR TITLE
Fixed OAuth issue when `:query` and `:body` are strings

### DIFF
--- a/lib/em-http/middleware/oauth.rb
+++ b/lib/em-http/middleware/oauth.rb
@@ -15,14 +15,19 @@ module EventMachine
 
       def request(client, head, body)
         request = client.req
+        uri     = request.uri.join(encode_query(request.uri, request.query))
+        params  = {}
 
-        uri = request.uri.join(encode_query(request.uri, request.query))
-
-        params = {}
+        # from https://github.com/oauth/oauth-ruby/blob/master/lib/oauth/request_proxy/em_http_request.rb
         if ["POST", "PUT"].include?(request.method)
-          CGI.parse(client.normalize_body(body)).each do |k,v|
-            # Since `CGI.parse` always returns values as an array
-            params[k] = v.size == 1 ? v.first : v
+          head["content-type"] ||= "application/x-www-form-urlencoded" if body.is_a? Hash
+          form_encoded = head["content-type"].to_s.downcase.start_with?("application/x-www-form-urlencoded")
+
+          if form_encoded
+            CGI.parse(client.normalize_body(body)).each do |k,v|
+              # Since `CGI.parse` always returns values as an array
+              params[k] = v.size == 1 ? v.first : v
+            end
           end
         end
 


### PR DESCRIPTION
Should have taken your advice on how to implement the query params from the beginning!

This pull request fixes OAuth for the following two cases:

``` ruby
EventMachine::HttpRequest.new('http://google.com/?q=paramA').get :query => 'q2=paramB'
EventMachine::HttpRequest.new('http://google.com/').post :body => "string"
```
