### PR TITLE
ArgumentError: wrong number of arguments (0 for 1)

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -134,7 +134,7 @@ module EventMachine
         @p << data
       rescue HTTP::Parser::Error => e
         c = @clients.shift
-        c.nil? ? unbind : c.on_error(e.message)
+        c.nil? ? unbind(e.message) : c.on_error(e.message)
       end
     end
 


### PR DESCRIPTION
This line was choking on an ArgumentError until I made this change, which also provides the benefit of being able to get the error message later on down the road.
