### PR TITLE
handle multiple Content-Type header response

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -267,9 +267,9 @@ module EventMachine
       end
 
       # handle malformed header - Content-Type repetitions.
-      charset = [response_header[CONTENT_TYPE]].flatten.first
+      content_type = [response_header[CONTENT_TYPE]].flatten.first
 
-      if String.method_defined?(:force_encoding) && /;\s*charset=\s*(.+?)\s*(;|$)/.match(charset)
+      if String.method_defined?(:force_encoding) && /;\s*charset=\s*(.+?)\s*(;|$)/.match(content_type)
         @content_charset = Encoding.find($1.gsub(/^\"|\"$/, '')) rescue Encoding.default_external
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -670,7 +670,7 @@ describe EventMachine::HttpRequest do
     EventMachine.run {
       response =<<-HTTP.gsub(/^ +/, '').strip
         HTTP/1.0 200 OK
-        Content-Type: text/plain; charset=latin1
+        Content-Type: text/plain; charset=iso-8859-1
         Content-Type: text/plain; charset=utf-8
         Content-Length: 5
         Connection: close
@@ -682,7 +682,7 @@ describe EventMachine::HttpRequest do
       http     = EventMachine::HttpRequest.new('http://127.0.0.1:8081/').get
       http.errback { failed(http) }
       http.callback {
-        http.response.encoding.should == Encoding::US_ASCII
+        http.content_charset.should == Encoding::ISO_8859_1
         EventMachine.stop
       }
     }


### PR DESCRIPTION
hiya,

when some dodgy servers send multiple Content-Type headers in a single response i've noticed my code crap out with 

lib/em-http/client.rb:269:in `match': can't convert Array to String (TypeError)

the patch fixes this problem
