### PR TITLE
bind to IP

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -49,7 +49,7 @@ module EventMachine
 
     def activate_connection(client)
       begin
-        EventMachine.connect(@connopts.host, @connopts.port, HttpStubConnection) do |conn|
+        EventMachine.bind_connect(@connopts.bind, @connopts.bind_port, @connopts.host, @connopts.port, HttpStubConnection) do |conn|
           post_init
 
           @deferred = false

--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -1,5 +1,5 @@
 class HttpConnectionOptions
-  attr_reader :host, :port, :tls, :proxy
+  attr_reader :host, :port, :tls, :proxy, :bind, :bind_port
   attr_reader :connect_timeout, :inactivity_timeout
 
   def initialize(uri, options)
@@ -9,6 +9,9 @@ class HttpConnectionOptions
     @tls   = options[:tls] || options[:ssl] || {}
     @proxy = options[:proxy]
 
+	@bind		= options[:bind] || '0.0.0.0'
+	@bind_port	= options[:bind_port] || 0
+	
     uri = uri.kind_of?(Addressable::URI) ? uri : Addressable::URI::parse(uri.to_s)
     uri.port = (uri.scheme == "https" ? (uri.port || 443) : (uri.port || 80))
 


### PR DESCRIPTION
Dear Ilya,

my first Pull request on Github. I hope the changes fit into your code. I saw in the eventmachine code that the normal connect method calls bind_connect handing over nil for host and nil for port. So I replaced the connect method in your code with bind_connect and added default for bind_host and bind_port.

Regards,

Daniel
