### PR TITLE
Don't normalize custom headers

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -15,11 +15,22 @@ module EventMachine
     LOCATION="LOCATION"
     HOST="HOST"
     ETAG="ETAG"
-
     CRLF="\r\n"
+    NORMALIZED_HEADERS = [
+      TRANSFER_ENCODING,
+      CONTENT_ENCODING,
+      CONTENT_LENGTH,
+      CONTENT_TYPE,
+      LAST_MODIFIED,
+      KEEP_ALIVE,
+      SET_COOKIE,
+      LOCATION,
+      HOST,
+      ETAG
+    ]
 
     attr_accessor :state, :response
-    attr_reader   :response_header, :error, :content_charset, :req, :cookies
+    attr_reader   :raw_header, :response_header, :error, :content_charset, :req, :cookies
 
     def initialize(conn, options)
       @conn = conn
@@ -203,7 +214,12 @@ module EventMachine
 
     def parse_response_header(header, version, status)
       header.each do |key, val|
-        @response_header[key.upcase.gsub('-','_')] = val
+        normalized = key.upcase.gsub('-','_')
+        if NORMALIZED_HEADERS.include?(normalized)
+          @response_header[normalized] = val
+        else
+          @response_header[key] = val
+        end
       end
 
       @response_header.http_version = version.join('.')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -687,4 +687,27 @@ describe EventMachine::HttpRequest do
       }
     }
   end
+
+  it 'should not normalize custom headers' do
+    EventMachine.run {
+      response =<<-HTTP.gsub(/^ +/, '').strip
+        HTTP/1.0 200 OK
+        Content-Type: text/plain; charset=iso-8859-1
+        Custom-Header: foo
+        Content-Length: 5
+        Connection: close
+
+        Hello
+      HTTP
+
+      @s       = StubServer.new(response)
+      http     = EventMachine::HttpRequest.new('http://127.0.0.1:8081/').get
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header["Custom-Header"].should == "foo"
+        EventMachine.stop
+      }
+    }
+  end
+
 end

--- a/spec/http_proxy_spec.rb
+++ b/spec/http_proxy_spec.rb
@@ -28,8 +28,8 @@ describe EventMachine::HttpRequest do
           http.response_header.status.should == 200
 
           # The test proxy server gives the requested uri back in this header
-          http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/?q=test'
-          http.response_header['X_THE_REQUESTED_URI'].should_not == '/?q=test'
+          http.response_header['X-The-Requested-URI'].should == 'http://127.0.0.1:8090/?q=test'
+          http.response_header['X-The-Requested-URI'].should_not == '/?q=test'
           http.response.should match('test')
           EventMachine.stop
         }

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -177,7 +177,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header['EM_MIDDLEWARE'].to_i.should == 3
+        http.response_header['EM-Middleware'].to_i.should == 3
         EM.stop
       }
     }


### PR DESCRIPTION
I can understand the reason for normalizing system headers, but it seems incorrect to "normalize" headers, especially custom ones.

This creates very unexpected behavior when using this to tease out headers.

Alternatively, it might be better to keep two versions of headers: one normalized and one raw. When the library relies on headers to make decisions, it can use the normalized copy, but callers should not see headers transformed in a way they didn't request.

Thanks for all your work on this!
