### PR TITLE
Allow indifferent access to response headers

### DIFF
--- a/lib/em-http/http_header.rb
+++ b/lib/em-http/http_header.rb
@@ -52,5 +52,9 @@ module EventMachine
     def location
       self[HttpClient::LOCATION]
     end
+
+    def [](key)
+      super(key) || super(key.upcase.gsub('-','_'))
+    end
   end
 end


### PR DESCRIPTION
You can access headers in their raw or normalized format:

```
http.response_header['Content-Type'].should == http.response_header['CONTENT_TYPE']
```
