### PR TITLE
fixing "regexp match /.../n against to UTF-8 string" warnings

### DIFF
--- a/lib/em-http/http_encoding.rb
+++ b/lib/em-http/http_encoding.rb
@@ -7,7 +7,7 @@ module EventMachine
       if defined?(EscapeUtils)
         EscapeUtils.escape_url(s.to_s)
       else
-        s.to_s.gsub(/([^a-zA-Z0-9_.-]+)/n) {
+        s.to_s.gsub(/([^a-zA-Z0-9_.-]+)/) {
           '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
         }
       end

--- a/spec/encoding_spec.rb
+++ b/spec/encoding_spec.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'helper'
 
 describe EventMachine::HttpEncoding do
@@ -30,6 +32,12 @@ describe EventMachine::HttpEncoding do
   it "should escape keys and values" do
     params = form_encode_body({'bad&str'=> {'key&key' => ['bad+&stuff', '[test]']}})
     params.should == "bad%26str[key%26key][0]=bad%2B%26stuff&bad%26str[key%26key][1]=%5Btest%5D"
+  end
+
+  it "should not issue warnings on non-ASCII encodings" do
+    # I don't know how to check for ruby warnings.
+    params = escape('valö') 
+    params = escape('valö'.encode('ISO-8859-15'))
   end
 
   # xit "should be fast on long string escapes" do


### PR DESCRIPTION
Since upgrading from 0.3.0 to 1.0.0 I get these warnings on each request:

```
lib/em-http/http_encoding.rb:10: warning: regexp match /.../n against to UTF-8 string
```

I don't know enough to overview the consequences, but removing the 'n' parameter from the escape regex removes this warning and all other specs are still running.

(Note that my "test case" isn't a real test as I don't know how to test ruby warnings. You'll have to look at the output of the spec.)
