### PR TITLE
slight API change on error at connection time

### DIFF
--- a/examples/fibered-http.rb
+++ b/examples/fibered-http.rb
@@ -33,6 +33,10 @@ EventMachine.run do
     puts "Setting up HTTP request #2"
     data = async_fetch('http://www.yahoo.com/')
     puts "Fetched page #2: #{data.response_header.status}"
+    
+    puts "Setting up HTTP request #3"
+    data = async_fetch('http://non-existing.domain/')
+    puts "Fetched page #3: #{data.response_header.status}"
 
     EventMachine.stop
   }.resume

--- a/spec/client_fiber_spec.rb
+++ b/spec/client_fiber_spec.rb
@@ -1,0 +1,21 @@
+require 'helper'
+require 'fiber'
+
+describe EventMachine::HttpRequest do
+  context "with fibers" do
+    it "should be transparent to connexion errors" do
+      EventMachine.run do
+        Fiber.new do
+          f = Fiber.current
+          http = EventMachine::HttpRequest.new('http://non-existing.domain/').get
+          http.callback {failed(http)}
+          http.errback {f.resume}
+          Fiber.yield
+          EventMachine.stop
+        end.resume
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
The example for fibers doesn't work if your DNS / routes are dead (i.e., on a TCP connection error of some reason):
The errback gets called immediately, hence you resume the fiber before yielding it.
I propose to call the close connection at next tick to maintain a consistent API.
Otherwise, users need to check the state of the connection before setting up callbacks/errbacks.

All specs pass, I've added one in a separate file because it requires 'fiber' which may not be available on 1.8.x

= next is commit text =

this simplifies the API

A problem is that the error callback should fire before setting it up.
Hence, if we are in a fiber, and if we expected to yield after setting up
callbacks/errbacks. We would resume the fiber before yielding it,
generating a double resume error.
We work around this problem by calling :close/:on_error at next tick.
Hence, the errback's fiber will predictably be EM's reactor fiber.
