### PR TITLE
Fixed redirections according to http://tools.ietf.org/html/rfc2616#section-14.30

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -100,6 +100,7 @@ module EventMachine
 
               @cookies.clear
               @cookies = @cookiejar.get(@response_header.location).map(&:to_s) if @req.pass_cookies
+              @req.set_method('GET') unless @response_header.status == 307
               @req.set_uri(@response_header.location)
               @conn.redirect(self)
             else

--- a/lib/em-http/http_client_options.rb
+++ b/lib/em-http/http_client_options.rb
@@ -48,4 +48,8 @@ class HttpClientOptions
     @port = @uri.port
 
   end
+
+  def set_method(method)
+    @method   = method.to_s.upcase
+  end
 end

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -124,6 +124,44 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  # According to RFC 2616 Section 10.3.3 this is the most common implementation
+  # in browsers. It's also how libraries such as HTTParty work
+  it "should use GET method for 302 redirects" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect/head/302').head :redirects => 1
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.req.method.should == 'GET'
+        EM.stop
+      }
+    }
+  end
+
+  it "should use GET method for 303 redirects" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect/head/303').head :redirects => 1
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.req.method.should == 'GET'
+        EM.stop
+      }
+    }
+  end
+
+  it "should not change method for 307 redirects" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect/head/307').head :redirects => 1
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.req.method.should == 'HEAD'
+        EM.stop
+      }
+    }
+  end
+
   it "should report last_effective_url" do
     EventMachine.run {
       http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -149,6 +149,18 @@ Stallion.saddle :spec do |stable|
       stable.response.status = 301
       stable.response["Location"] = "/"
 
+    elsif stable.request.path_info == '/redirect/head/302'
+      stable.response.status = 302
+      stable.response["Location"] = "/"
+
+    elsif stable.request.path_info == '/redirect/head/303'
+      stable.response.status = 303
+      stable.response["Location"] = "/"
+
+    elsif stable.request.path_info == '/redirect/head/307'
+      stable.response.status = 307
+      stable.response["Location"] = "/"
+
     elsif stable.request.path_info == '/redirect/middleware_redirects_1'
       stable.response.status = 301
       stable.response["EM-Middleware"] = stable.request.env["HTTP_EM_MIDDLEWARE"]


### PR DESCRIPTION
According to RFC 2616, most browsers implement redirections changing the HTTP method to GET.

This is also how libraries such as HTTParty work.

This patch changes the HTTP method to GET for redirections other than 307 redirects.
