### PR TITLE
Bug sending full URI with socks5 proxy

### DIFF
--- a/lib/em-http/http_encoding.rb
+++ b/lib/em-http/http_encoding.rb
@@ -49,9 +49,9 @@ module EventMachine
     def encode_request(method, uri, query, proxy)
       query = encode_query(uri, query)
 
-      # Non CONNECT proxies require that you provide the full request
+      # Some Non CONNECT proxies require that you provide the full request
       # uri in request header, as opposed to a relative path.
-      query = uri.join(query) if proxy
+      query = uri.join(query) if proxy and proxy[:type] != :socks5
 
       HTTP_REQUEST_HEADER % [method.to_s.upcase, query]
     end


### PR DESCRIPTION
When EventMachine::HttpRequest was configured to use proxy, the whole uri is sent in the HTTP request instead of just the path.  Comment in the code indicates this was intentionally, but I found this to not be the case using the SOCKS5 proxy built into openssh (-D command line option).

I have access to no others socks5 proxies to test, but this pull fixed the problem in my case.
