### PR TITLE
allow SSL certs to be verified

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -28,6 +28,36 @@ module EventMachine
     def unbind(reason=nil)
       @parent.unbind(reason)
     end
+
+    def ssl_verify_peer(cert_str)
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+
+      is_signing_auth = cert_is_signing_auth(cert)
+      result = (is_signing_auth || OpenSSL::SSL.verify_certificate_identity(cert, parent.connopts.host)) &&
+        cert_chain.any? {|c| cert.verify(c.public_key) } &&
+        cert.not_after >= Time.now &&
+        cert.not_before <= Time.now
+
+      cert_chain << cert if result && is_signing_auth
+      result
+    end
+
+    private
+    def cert_chain_str
+      @cert_chain_str ||= File.read(parent.connopts.tls[:cert_chain_file])
+    end
+
+    def cert_chain
+      @cert_chain ||= begin
+        strings = cert_chain_str.lines("-----END CERTIFICATE-----").map{|x| x.strip}.compact.reject{|x| x==''}
+        strings.map{|s| OpenSSL::X509::Certificate.new(s) }
+      end
+    end
+
+    def cert_is_signing_auth(cert)
+      ext = cert.extensions.detect { |ext| ext.oid == "basicConstraints" }
+      ext && ext.value.split(/,\s+/).any? { |val| val == "CA:TRUE" }
+    end
   end
 
   class HttpConnection


### PR DESCRIPTION
Currently if the option :verify_peer is set to true, all requests will fail. This is because ssl_verify_peer is not implemented. According to the EM docs, "It is up to user defined code to perform a check on the certificates."

Since the method isn't defined by em-http-request, it returns nil, and all https requests fail.

I have attach a first stab at implementing this method. It is lacking tests, and this is almost certainly not a completely correct way of verifying the SSL certs; however, it is far better than not verifying SSL certs at all.

Are you interested in including this feature in em-http-request? Can anyone make some suggestion for improving the cert checking?
