### PR TITLE
Make em-socksify and cookiejar optional

### DIFF
--- a/lib/em-http.rb
+++ b/lib/em-http.rb
@@ -1,5 +1,9 @@
 require 'eventmachine'
+begin
 require 'em-socksify'
+rescue LoadError
+	# Only need this if using SOCKS
+end
 require 'addressable/uri'
 require 'http/parser'
 

--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -1,4 +1,8 @@
-require 'cookiejar'
+begin
+  require 'cookiejar'
+rescue LoadError
+  # We only need cookiejar if using cookies
+end
 
 module EventMachine
 
@@ -293,7 +297,9 @@ module EventMachine
 
     class CookieJar
       def initialize
-        @jar = ::CookieJar::Jar.new
+        if defined?(::CookieJar)
+          @jar = ::CookieJar::Jar.new
+        end
       end
 
       def set string, uri
@@ -301,6 +307,7 @@ module EventMachine
       end
 
       def get uri
+        return nil unless @jar
         uri = URI.parse(uri) rescue nil
         uri ? @jar.get_cookies(uri) : []
       end

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -33,7 +33,10 @@ module EventMachine
 
   class HttpConnection
     include HTTPMethods
-    include Socksify
+
+    if defined?(Socksify)
+      include Socksify
+    end
 
     attr_reader :deferred
     attr_accessor :error, :connopts, :uri, :conn
@@ -148,6 +151,7 @@ module EventMachine
       @peer = @conn.get_peername
 
       if @connopts.proxy && @connopts.proxy[:type] == :socks5
+        raise 'Need to install em-socksify to use socks5 proxy!' unless defined?(Socksify)
         socksify(client.req.uri.host, client.req.uri.port, *@connopts.proxy[:authorization]) { start }
       else
         start


### PR DESCRIPTION
These dependencies are only needed if you're doing SOCKS5 proxying or need Cookie support.
