### PR TITLE
Expose raw response headers

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -218,6 +218,7 @@ module EventMachine
     end
 
     def parse_response_header(header, version, status)
+      @response_header.raw = header
       header.each do |key, val|
         @response_header[key.upcase.gsub('-','_')] = val
       end

--- a/lib/em-http/http_header.rb
+++ b/lib/em-http/http_header.rb
@@ -11,6 +11,9 @@ module EventMachine
     # The status code (as a string!)
     attr_accessor :http_status
 
+    # Raw headers
+    attr_accessor :raw
+
     # E-Tag
     def etag
       self[HttpClient::ETAG]

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -356,6 +356,20 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  it "should return raw headers in a hash" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/echo_headers').get
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.response_header.raw['Set-Cookie'].should match('test=yes')
+        http.response_header.raw['X-Forward-Host'].should match('proxy.local')
+        EventMachine.stop
+      }
+    }
+  end
+
   it "should detect deflate encoding" do
     EventMachine.run {
 

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -85,6 +85,11 @@ Stallion.saddle :spec do |stable|
       stable.response["Last-Modified"] = "Fri, 13 Aug 2010 17:31:21 GMT"
       stable.response.write stable.request.query_string
 
+    elsif stable.request.path_info == '/echo_headers'
+      stable.response["Set-Cookie"] = "test=yes"
+      stable.response["X-Forward-Host"] = "proxy.local"
+      stable.response.write stable.request.query_string
+
     elsif stable.request.path_info == '/echo_content_length'
       stable.response.write stable.request.content_length
 


### PR DESCRIPTION
This is useful for use in a reverse proxy, which is what I am using it for here locally.

relates to issue #145
