### PR TITLE
set deferred if the connection becomes inactive

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -184,6 +184,9 @@ module EventMachine
         rescue EventMachine::ConnectionError => e
           @clients.pop.close(e.message)
         end
+      else
+        @conn = nil
+        @deferred = true
       end
     end
     alias :close :unbind


### PR DESCRIPTION
Corrects missing branch condition when connections fail.
