### PR TITLE
Middleware for OAuth2

### DIFF
--- a/lib/em-http/middleware/oauth2.rb
+++ b/lib/em-http/middleware/oauth2.rb
@@ -1,0 +1,28 @@
+module EventMachine
+  module Middleware
+    class OAuth2
+      include EM::HttpEncoding
+      attr_accessor :access_token
+
+      def initialize(opts={})
+        self.access_token = opts[:access_token] or raise "No :access_token provided"
+      end
+
+      def request(client, head, body)
+        uri = client.req.uri.dup
+        update_uri! uri
+        client.req.set_uri uri
+
+        [head, body]
+      end
+
+      def update_uri!(uri)
+        if uri.query.nil?
+          uri.query = encode_param(:access_token, access_token)
+        else
+          uri.query += "&#{encode_param(:access_token, access_token)}"
+        end
+      end
+    end
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 
 require 'em-http'
+require 'em-http/middleware/oauth2'
 require 'yajl'
 
 require 'stallion'

--- a/spec/middleware/oauth2_spec.rb
+++ b/spec/middleware/oauth2_spec.rb
@@ -1,0 +1,15 @@
+describe EventMachine::Middleware::OAuth2 do
+  it "should add an access token to a URI with no query parameters" do
+    middleware = EventMachine::Middleware::OAuth2.new(:access_token => "fedcba9876543210")
+    uri = Addressable::URI.parse("https://graph.facebook.com/me")
+    middleware.update_uri! uri
+    uri.to_s.should == "https://graph.facebook.com/me?access_token=fedcba9876543210"
+  end
+
+  it "should add an access token to a URI with query parameters" do
+    middleware = EventMachine::Middleware::OAuth2.new(:access_token => "fedcba9876543210")
+    uri = Addressable::URI.parse("https://graph.facebook.com/me?fields=photo")
+    middleware.update_uri! uri
+    uri.to_s.should == "https://graph.facebook.com/me?fields=photo&access_token=fedcba9876543210"
+  end
+end


### PR DESCRIPTION
Although OAuth2 is much simpler to implement than OAuth1, it's nice to be able to use a consistent API for making HTTP requests with both.

Please let me know if the implementation needs more work,

Conrad
