### PR TITLE
Fix example of async_fetch

### DIFF
--- a/examples/fibered-http.rb
+++ b/examples/fibered-http.rb
@@ -9,7 +9,7 @@ require 'fiber'
 
 def async_fetch(url)
   f = Fiber.current
-  http = EventMachine::HttpRequest.new(url).get :timeout => 10
+  http = EventMachine::HttpRequest.new(url, :connect_timeout => 10, :inactivity_timeout => 20).get
 
   http.callback { f.resume(http) }
   http.errback  { f.resume(http) }


### PR DESCRIPTION
Because example of async_fetch method with timeout option is wrong.
