### PR TITLE
HttpRequest doesn't mutate the URI if it's an Addressable::URI

### DIFF
--- a/lib/em-http/request.rb
+++ b/lib/em-http/request.rb
@@ -3,6 +3,7 @@ module EventMachine
     @middleware = []
 
     def self.new(uri, options={})
+      uri = uri.clone
       connopt = HttpConnectionOptions.new(uri, options)
 
       c = HttpConnection.new


### PR DESCRIPTION
If you pass an `Addressable::URI` into an `HttpRequest`, it mutates the instance by setting the port on it. This is unexpected to the caller, why would the port on the URI be set just by requesting it?

This change clones the uri that's passed in before mutating it.

I'm not sure if this is the best solution, but it's certainly the least impact. I'm not really confortable with the idea of `HttpConnectionOptions` mutating the URL at all, but stopping that would require a small refactor.
