### PR TITLE
Redirection dose not work with path or query option.

### DIFF
--- a/lib/em-http/http_client_options.rb
+++ b/lib/em-http/http_client_options.rb
@@ -29,6 +29,7 @@ class HttpClientOptions
   def no_body?; @method == "HEAD"; end
 
   def set_uri(uri)
+    @path = @query = nil if @uri # clear path and query except first time.
     uri = uri.kind_of?(Addressable::URI) ? uri : Addressable::URI::parse(uri.to_s)
     uri.path = '/' if uri.path.empty?
     uri.path = @path if @path

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -40,6 +40,20 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  it "should follow location redirects with path and query" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get :path => '/redirect', :query => 'q=1', :redirects => 1
+      http.errback { failed(http) }
+      http.callback {
+        http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
+        http.response_header.status.should == 200
+        http.redirects.should == 1
+
+        EM.stop
+      }
+    }
+  end
+
   it "should not follow redirects on created" do
     EventMachine.run {
       http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect/created').get :redirects => 1


### PR DESCRIPTION
Redirection dose not work properly when HttpConnection#get
is called with :path or :query options.

This patch clear @path and @query from request option when
HttpClientOptions#set_uri is called again.
