### PR TITLE
Make proxy: {type: :http} work for https requests

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -156,7 +156,7 @@ module EventMachine
     end
 
     def start
-      @conn.start_tls(@connopts.tls) if client && client.req.ssl?
+      @conn.start_tls(@connopts.tls) if client && client.req.ssl? && !@connopts.http_proxy?
       @conn.succeed
     end
 

--- a/spec/stub_server.rb
+++ b/spec/stub_server.rb
@@ -33,6 +33,7 @@ class StubServer
     @sig = EventMachine::start_server(host, port, Server) do |server|
       server.response = options[:response]
       server.echo     = options[:echo]
+      server.start_tls if options[:https]
     end
   end
 


### PR DESCRIPTION
Before this change the code was trying to establish a secure connection
to the proxy server; after this change an unencrypted connection is used
to the proxy server which is itself responsible for making further
requests upstream.

Fixes: #146
Closes: #236
