### PR TITLE
http_parser.rb 0.6.0 is now stable

### DIFF
--- a/em-http-request.gemspec
+++ b/em-http-request.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cookiejar'
   s.add_dependency 'em-socksify', '>= 0.3'
   s.add_dependency 'eventmachine', '>= 1.0.3'
-  s.add_dependency 'http_parser.rb', '>= 0.6.0.beta.2'
+  s.add_dependency 'http_parser.rb', '>= 0.6.0'
 
   s.add_development_dependency 'mongrel', '~> 1.2.0.pre2'
   s.add_development_dependency 'multi_json'


### PR DESCRIPTION
This is causing conflicts with other gems also using http_parser.rb.
