### PR TITLE
Fix nil bug

### DIFF
--- a/lib/em-http/http_client_options.rb
+++ b/lib/em-http/http_client_options.rb
@@ -41,7 +41,7 @@ class HttpClientOptions
     # Make sure the ports are set as Addressable::URI doesn't
     # set the port if it isn't there
     if @port.nil?
-      @port = @uri.scheme == "https" ? 443 : 80
+      @uri.port = @port = @uri.scheme == "https" ? 443 : 80
     end
 
   end

--- a/lib/em-http/http_client_options.rb
+++ b/lib/em-http/http_client_options.rb
@@ -1,6 +1,6 @@
 class HttpClientOptions
-  attr_reader :uri, :method, :host, :port
-  attr_reader :headers, :file, :body, :query, :path
+  attr_reader :uri, :method
+  attr_reader :headers, :file, :body, :query
   attr_reader :keepalive, :pass_cookies, :decoding
 
   attr_accessor :followed, :redirects
@@ -34,15 +34,24 @@ class HttpClientOptions
     uri.path = '/' if uri.path.empty?
 
     @uri = uri
-    @path = uri.path
-    @host = uri.host
-    @port = uri.port
 
     # Make sure the ports are set as Addressable::URI doesn't
     # set the port if it isn't there
-    if @port.nil?
-      @uri.port = @port = @uri.scheme == "https" ? 443 : 80
+    if @uri.port.nil?
+      @uri.port = @uri.scheme == "https" ? 443 : 80
     end
 
+  end
+
+  def path
+    @uri.path
+  end
+
+  def host
+    @uri.host
+  end
+
+  def port
+    @uri.port
   end
 end


### PR DESCRIPTION
Fixes #259.

The first commit fixes the issue, which is that although @port was being set, @uri.port was not. The committer of 043eb0 probably got confused by the two different ways to set the port, so the second commit refactors the class to get rid of the instance variables (@port, @host, @path) that duplicate those already contained within @uri.