### PR TITLE
lock down cookiejar version

### DIFF
--- a/em-http-request.gemspec
+++ b/em-http-request.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'addressable', '>= 2.3.4'
   s.add_dependency 'cookiejar', '<= 0.3.0'
-  s.add_dependency 'em-socksify', '<= 0.3.1'
+  s.add_dependency 'em-socksify', '>= 0.3'
   s.add_dependency 'eventmachine', '>= 1.0.3'
   s.add_dependency 'http_parser.rb', '>= 0.6.0'
 


### PR DESCRIPTION
Current version of `cookiejar` is [broken](https://github.com/dwaite/cookiejar/issues/13). `em-http-request` fetches the latest version of `cookiejar` and breaks on require. 

```
irb(main):001:0> require 'em-http-request'
LoadError: cannot load such file -- cookiejar
        from /usr/local/Cellar/ruby/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
        from /usr/local/Cellar/ruby/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
        from /usr/local/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/em-http-request-1.1.2/lib/em-http/client.rb:1:in `<top (required)>'
```

To reproduce, run `sudo gem uninstall cookiejar em-http-request && sudo gem install em-http-request && ruby -e "require 'em-http-request'"`
