### PR TITLE
Lock cookiejar at 0.3.0

### DIFF
--- a/em-http-request.gemspec
+++ b/em-http-request.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'em-http-request'
 
   s.add_dependency 'addressable', '>= 2.3.4'
-  s.add_dependency 'cookiejar', '<= 0.3.0'
+  s.add_dependency 'cookiejar', '0.3.0'
   s.add_dependency 'em-socksify', '>= 0.3'
   s.add_dependency 'eventmachine', '>= 1.0.3'
   s.add_dependency 'http_parser.rb', '>= 0.6.0'


### PR DESCRIPTION
Per this issue: https://github.com/dwaite/cookiejar/issues/13#issuecomment-37520773

This should probably be considered urgent.
