### PR TITLE
Remove content-encoding header when response is decoded

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -285,6 +285,7 @@ module EventMachine
       end
 
       if @req.decoding && decoder_class = HttpDecoders.decoder_for_encoding(response_header[CONTENT_ENCODING])
+        response_header.delete(CONTENT_ENCODING)
         begin
           @content_decoder = decoder_class.new do |s| on_decoded_body_data(s) end
         rescue HttpDecoders::DecoderError

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -378,7 +378,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "deflate"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == "compressed"
 
         EventMachine.stop
@@ -394,7 +394,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == "compressed"
 
         EventMachine.stop
@@ -413,7 +413,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == ''
 
         actual_response.should == expected_response
@@ -621,7 +621,7 @@ describe EventMachine::HttpRequest do
 
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "deflate"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == ''
         body.should == "compressed"
         EventMachine.stop

--- a/spec/external_spec.rb
+++ b/spec/external_spec.rb
@@ -89,7 +89,7 @@ requires_connection do
         http.errback { failed(http) }
         http.callback {
           http.response_header.status.should == 200
-          http.response_header["CONTENT_ENCODING"].should == "deflate"
+          http.response_header["CONTENT_ENCODING"].should be_nil
 
           EventMachine.stop
         }
@@ -105,7 +105,7 @@ requires_connection do
         http.errback { failed(http) }
         http.callback {
           http.response_header.status.should == 200
-          http.response_header["CONTENT_ENCODING"].should == "gzip"
+          http.response_header["CONTENT_ENCODING"].should be_nil
           http.response.should == ''
 
           EventMachine.stop

--- a/spec/http_proxy_spec.rb
+++ b/spec/http_proxy_spec.rb
@@ -76,7 +76,7 @@ describe EventMachine::HttpRequest do
           http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/gzip'
           http.response_header['X_THE_REQUESTED_URI'].should_not == '/redirect'
 
-          http.response_header["CONTENT_ENCODING"].should == "gzip"
+          http.response_header["CONTENT_ENCODING"].should be_nil
           http.response.should == "compressed"
           http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
           http.redirects.should == 1

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -30,7 +30,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == "compressed"
         http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
         http.redirects.should == 1
@@ -141,7 +141,7 @@ describe EventMachine::HttpRequest do
 
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == "compressed"
         http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
         http.redirects.should == 3
@@ -246,7 +246,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == "compressed"
         http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
         http.redirects.should == 2
@@ -264,7 +264,7 @@ describe EventMachine::HttpRequest do
       http.errback { failed(http) }
       http.callback {
         http.response_header.status.should == 200
-        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response_header["CONTENT_ENCODING"].should be_nil
         http.response.should == "compressed"
         http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
         http.redirects.should == 2


### PR DESCRIPTION
I'm guessing others have different opinions on this, but I believe em-http-request should remove the Content-Encoding header when it decodes a response itself.

This allows em-http-request to operate more consistently with other http libraries (including Net::HTTP) when used in projects like Faraday with interchangeable adapters. It also fits the idea that content encoding should be "transparent" to the application - handled entirely at the protocol level.

As an example, this behavior is currently breaking the Google API Ruby Client (https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client/gzip.rb) when Faraday uses the em_synchrony adapter since the Google client assumes that if Content-Encoding is set to "gzip", it should decompress it there. Since em-http-request is returning a decompressed body *and* the "Content-Encoding: gzip" header, the Google API Client is failing when attempting to decompress the (already decompressed) body.

Of course, some may be of the opinion that the problem should be fixed higher up (in Faraday or the Google client in this case), but I feel like it's perfectly reasonable for a higher-level project to assume consistency between the Content-Encoding header and body data.

I'd love to hear other thoughts on this.