### PR TITLE
Added support for forcefully closing the connection

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -119,6 +119,12 @@ module EventMachine
       end
     end
 
+    # Forcefully close the connection
+    def close!
+      @conn.unbind 'connection terminated'
+      on_error 'connection terminated'
+    end
+
     def on_error(msg = nil)
       @error = msg
       fail(self)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -886,3 +886,22 @@ describe EventMachine::HttpRequest do
     end
   end
 end
+
+describe EventMachine::HttpClient do
+  describe '#close!' do
+    let(:conn) { double :conn, unbind: nil }
+    subject { EM::HttpClient.new conn, {} }
+
+    it 'should unbind the connection' do
+      expect(conn).to receive :unbind
+
+      subject.close!
+    end
+
+    it 'should trigger an error' do
+      expect(subject).to receive :on_error
+
+      subject.close!
+    end
+  end
+end


### PR DESCRIPTION
This is useful for connections where you don't want to receive the whole body
if the content-length exceeds a certain amount. You could then just close the
connection.

Comments on whether this way actually closes it somewhat gracefully would be appreciated.
