### PR TITLE
Pass default port if port is nil

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -152,9 +152,9 @@ module EventMachine
       @peer = @conn.get_peername
 
       if @connopts.socks_proxy?
-        socksify(client.req.uri.host, client.req.uri.port, *@connopts.proxy[:authorization]) { start }
+        socksify(client.req.uri.host, client.req.uri.port || client.req.uri.default_port, *@connopts.proxy[:authorization]) { start }
       elsif @connopts.connect_proxy?
-        connectify(client.req.uri.host, client.req.uri.port, *@connopts.proxy[:authorization]) { start }
+        connectify(client.req.uri.host, client.req.uri.port || client.req.uri.default_port, *@connopts.proxy[:authorization]) { start }
       else
         start
       end


### PR DESCRIPTION
Addressable::URI returns nil for  port, if it is not provided in an URI
So, ```.default_port``` should be used instead

Because of this, URIs without port part do not work with SOCKS proxies.

    > Addressable::URI.parse('http://test.ru').port
    => nil
    > Addressable::URI.parse('http://test.ru').default_port
    => 80

Ref: https://github.com/sporkmonger/addressable/issues/179