### PR TITLE
Make EventMachine::HttpResponseHeader.http_status match docs

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -114,7 +114,7 @@ module EventMachine
       @p = Http::Parser.new
       @p.header_value_type = :mixed
       @p.on_headers_complete = proc do |h|
-        client.parse_response_header(h, @p.http_version, @p.status_code)
+        client.parse_response_header(h, @p.http_version, @p.status_code.to_s)
         :reset if client.req.no_body?
       end
 


### PR DESCRIPTION
Docs say that #http_status returns a string (in fact, it's *very* emphatic
on that point).  Except that Http::Parser#status_code returns an integer.
The relevant line of code is `ext/ruby_http_parser/ruby_http_parser.c`:429:

    return INT2FIX(wrapper->parser.status_code);
