### PR TITLE
Use Base64.strict_encode64 instead of Base64.encode64.

### DIFF
--- a/lib/em-http/http_encoding.rb
+++ b/lib/em-http/http_encoding.rb
@@ -114,7 +114,7 @@ module EventMachine
     #     String - custom auth string (OAuth, etc)
     def encode_auth(k,v)
       if v.is_a? Array
-        FIELD_ENCODING % [k, ["Basic", Base64.encode64(v.join(":")).split.join].join(" ")]
+        FIELD_ENCODING % [k, ["Basic", Base64.strict_encode64(v.join(":")).split.join].join(" ")]
       else
         encode_field(k,v)
       end

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -234,7 +234,7 @@ Stallion.saddle :spec do |stable|
       stable.response.status = 200
       stable.response.write stable.request.env["HTTP_AUTHORIZATION"]
     elsif stable.request.path_info == '/authtest'
-      auth = "Basic %s" % Base64.encode64(['user', 'pass'].join(':')).split.join
+      auth = "Basic %s" % Base64.strict_encode64(['user', 'pass'].join(':')).split.join
       if auth == stable.request.env["HTTP_AUTHORIZATION"]
         stable.response.status = 200
         stable.response.write 'success'


### PR DESCRIPTION
Currently, when [encoding a basic authorization header passed as an array](https://github.com/igrigorik/em-http-request/blob/master/lib/em-http/http_encoding.rb#L117) `Base64.encode64` is used. This is fine as long as the username and password being encoded are under 60 characters combined. `Base64.encode64` inserts line feeds [every 60 encoded characters](http://ruby-doc.org/stdlib-2.2.0/libdoc/base64/rdoc/Base64.html#method-i-encode64).

This pull request simply uses `Base64.strict_encode64` anywhere that `Base64.encode64` was previously used. This behaves the same way, but without the insertion of line feeds every 60 encoded characters.