### PR TITLE
Ignore query option when redirecting

### DIFF
--- a/lib/em-http/http_client_options.rb
+++ b/lib/em-http/http_client_options.rb
@@ -12,8 +12,6 @@ class HttpClientOptions
 
     @method   = method.to_s.upcase
     @headers  = options[:head] || {}
-    @query    = options[:query]
-
 
     @file     = options[:file]
     @body     = options[:body]
@@ -21,14 +19,14 @@ class HttpClientOptions
     @pass_cookies = options.fetch(:pass_cookies, true)  # pass cookies between redirects
     @decoding     = options.fetch(:decoding, true)      # auto-decode compressed response
 
-    set_uri(uri, options[:path])
+    set_uri(uri, options[:path], options[:query])
   end
 
   def follow_redirect?; @followed < @redirects; end
   def ssl?; @uri.scheme == "https" || @uri.port == 443; end
   def no_body?; @method == "HEAD"; end
 
-  def set_uri(uri, path = nil)
+  def set_uri(uri, path = nil, query = nil)
     uri = uri.kind_of?(Addressable::URI) ? uri : Addressable::URI::parse(uri.to_s)
     uri.path = path if path
     uri.path = '/' if uri.path.empty?
@@ -37,6 +35,7 @@ class HttpClientOptions
     @path = uri.path
     @host = uri.host
     @port = uri.port
+    @query = query
 
     # Make sure the ports are set as Addressable::URI doesn't
     # set the port if it isn't there

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -362,4 +362,20 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  it "should ignore query option when redirecting" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect/ignore_query_option').get :redirects => 1, :query => 'ignore=1'
+      http.errback { failed(http) }
+      http.callback {
+        http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/redirect/url'
+        http.redirects.should == 1
+
+        redirect_url = http.response
+        redirect_url.should == http.last_effective_url.to_s
+
+        EM.stop
+      }
+    }
+  end
+
 end

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -201,6 +201,14 @@ Stallion.saddle :spec do |stable|
       stable.response.status = 301
       stable.response["Location"] = "https://host:443/"
 
+    elsif stable.request.path_info == '/redirect/ignore_query_option'
+      stable.response.status = 301
+      stable.response['Location'] = '/redirect/url'
+
+    elsif stable.request.path_info == '/redirect/url'
+      stable.response.status = 200
+      stable.response.write stable.request.url
+
     elsif stable.request.path_info == '/gzip'
       io = StringIO.new
       gzip = Zlib::GzipWriter.new(io)


### PR DESCRIPTION
Suppose page `http://example1/` redirects to `http://example2/`.

Then the following request

```ruby
EventMachine::HttpRequest.new('http://example1/').get(query: 'original_query=1')
```
will use query option when following redirect. The redirect request URI will be
`http://example2/?original_query=1`