### PR TITLE
stop redirect after failing

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -100,6 +100,8 @@ module EventMachine
         c.callback(&m.method(:response)) if m.respond_to?(:response)
       end
 
+      c.errback { c.req.redirects = 0 }
+
       @clients.push c
     end
 

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -100,7 +100,7 @@ module EventMachine
         c.callback(&m.method(:response)) if m.respond_to?(:response)
       end
 
-      c.errback { c.req.redirects = 0 }
+      c.errback { @conn.close_connection }
 
       @clients.push c
     end

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -209,6 +209,15 @@ Stallion.saddle :spec do |stable|
       stable.response.status = 200
       stable.response.write stable.request.url
 
+    elsif stable.request.path_info == '/slow_redirect/ok'
+      sleep(1)
+      stable.response.status = 301
+      stable.response["Location"] = "/ok"
+
+    elsif stable.request.path_info == "/ok"
+      stable.response.status = 200
+      stable.response.write "ok"
+
     elsif stable.request.path_info == '/gzip'
       io = StringIO.new
       gzip = Zlib::GzipWriter.new(io)


### PR DESCRIPTION
Problem: redirect doesn't stop even after the 'fail' was invoked.