### PR TITLE
Fix the issue when redirect request is triggered only after connection inactivity timeout

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -103,6 +103,7 @@ module EventMachine
               @req.set_uri(@response_header.location)
 
               @conn.redirect(self)
+              @conn.conn.close_connection
             else
               succeed(self)
             end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,7 +51,7 @@ describe EventMachine::HttpRequest do
     EventMachine.run {
       lambda {
       EventMachine::HttpRequest.new('random?text').get
-    }.should raise_error
+    }.should raise_error(Addressable::URI::InvalidURIError)
 
     EM.stop
     }

--- a/spec/redirect_spec.rb
+++ b/spec/redirect_spec.rb
@@ -378,4 +378,29 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  it "should work with persistent connections" do
+    Timeout.timeout(1) {
+      EventMachine.run {
+        response =<<-HTTP.gsub(/^ +/, '')
+          HTTP/1.1 301 MOVED PERMANENTLY
+          Location: http://127.0.0.1:8090/
+          Content-Length: 0
+
+        HTTP
+
+        stub_server = StubServer.new(:host => '127.0.0.1', :port => 8070, :keepalive => true, :response => response)
+        conn = EventMachine::HttpRequest.new('http://127.0.0.1:8070/', :inactivity_timeout => 60)
+        http = conn.get :redirects => 1, :keepalive => true
+        http.errback { failed(http) }
+        http.callback {
+          http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/'
+          http.redirects.should == 1
+
+          stub_server.stop
+          EM.stop
+        }
+      }
+    }
+  end
+
 end

--- a/spec/stub_server.rb
+++ b/spec/stub_server.rb
@@ -1,5 +1,7 @@
 class StubServer
   module Server
+    attr_accessor :keepalive
+
     def receive_data(data)
       if echo?
         send_data("HTTP/1.0 200 OK\r\nContent-Length: #{data.bytesize}\r\nContent-Type: text/plain\r\n\r\n")
@@ -8,7 +10,7 @@ class StubServer
         send_data @response
       end
 
-      close_connection_after_writing
+      close_connection_after_writing unless keepalive
     end
 
     def echo= flag
@@ -31,8 +33,9 @@ class StubServer
     host = options[:host]
     port = options[:port]
     @sig = EventMachine::start_server(host, port, Server) do |server|
-      server.response = options[:response]
-      server.echo     = options[:echo]
+      server.response  = options[:response]
+      server.echo      = options[:echo]
+      server.keepalive = options[:keepalive]
     end
   end
 


### PR DESCRIPTION
Solves issue #276.

I am not sure if my solution is good. It keeps the existing behaviour except that redirect request is triggered right away.