### PR TITLE
Rescue from StandardError instead of Exception

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -106,7 +106,7 @@ module EventMachine
               succeed(self)
             end
 
-          rescue Exception => e
+          rescue => e
             on_error(e.message)
           end
         else

--- a/lib/em-http/middleware/json_response.rb
+++ b/lib/em-http/middleware/json_response.rb
@@ -7,7 +7,7 @@ module EventMachine
         begin
           body = MultiJson.load(resp.response)
           resp.response = body
-        rescue Exception => e
+        rescue => e
         end
       end
     end

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -265,7 +265,7 @@ end
 Thread.new do
   begin
     Stallion.run :Host => '127.0.0.1', :Port => 8090
-  rescue Exception => e
+  rescue => e
     print e
   end
 end


### PR DESCRIPTION
Don't raise/rescue Exception classes, use StandardError instead.

https://robots.thoughtbot.com/rescue-standarderror-not-exception
https://www.relishapp.com/womply/ruby-style-guide/docs/exceptions
http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby/10048406#10048406