### PR TITLE
Fix basic auth and proxy

### DIFF
--- a/lib/em-http/http_encoding.rb
+++ b/lib/em-http/http_encoding.rb
@@ -53,7 +53,12 @@ module EventMachine
       # uri in request header, as opposed to a relative path.
       # Don't modify the header with CONNECT proxies. It's unneeded and will
       # cause 400 Bad Request errors with many standard setups.
-      query = uri.join(query) if connopts.proxy && !connopts.connect_proxy?
+      if connopts.proxy && !connopts.connect_proxy?
+        query = uri.join(query)
+        # Drop the userinfo, it's been converted to a header and won't be
+        # accepted by the proxy
+        query.userinfo = nil
+      end
 
       HTTP_REQUEST_HEADER % [method.to_s.upcase, query]
     end

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -17,7 +17,7 @@ module Stallion
 
     def match?(request)
       method = request['REQUEST_METHOD']
-      right_method = @methods.empty? or @methods.include?(method)
+      @methods.empty? or @methods.include?(method)
     end
   end
 
@@ -36,7 +36,7 @@ module Stallion
 
     def call(request, response)
       @request, @response = request, response
-      @boxes.each do |(path, methods), mount|
+      @boxes.each do |_, mount|
         if mount.match?(request)
           mount.ride
         end

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -96,6 +96,9 @@ Stallion.saddle :spec do |stable|
     elsif stable.request.path_info == '/echo_content_length_from_header'
       stable.response.write "content-length:#{stable.request.env["CONTENT_LENGTH"]}"
 
+    elsif stable.request.path_info == '/echo_authorization_header'
+      stable.response.write "authorization:#{stable.request.env["HTTP_AUTHORIZATION"]}"
+
     elsif stable.request.head? && stable.request.path_info == '/'
       stable.response.status = 200
 


### PR DESCRIPTION
When requesting via an HTTP proxy, we put the entire URI in the position
where usually the path and query string is expected. However, if the
original URI included a basic auth section, we must not include it, but
rather convert it to an `Authorization` header.