### PR TITLE
Prevent data corruption when decoding gzip stream, fixes #284

### DIFF
--- a/lib/em-http/decoders.rb
+++ b/lib/em-http/decoders.rb
@@ -127,7 +127,6 @@ module EventMachine::HttpDecoders
 
     def extract_stream(compressed)
       @data << compressed
-      pos = @pos
 
       while !eof? && !finished?
         buffer = ""
@@ -208,7 +207,7 @@ module EventMachine::HttpDecoders
       end
 
       if finished?
-        compressed[(@pos - pos)..-1]
+        compressed[(@pos - (@data.length - compressed.length))..-1]
       else
         ""
       end


### PR DESCRIPTION
Hi! 👋 

This fixes an issue where a gzip stream chunked into strangely-sized pieces would result in a buffer overrun when decoding the headers (causing the problem described in #284).

Previously the position where the headers end in `compressed` was determined by the delta of `@pos` before and after reading the headers. This didn't take into account the fact that `@data` may already contain data, but not enough to have advanced `@pos` on previous iterations.

Thanks for your excellent work on maintaining this project ❤️ 