### PR TITLE
Support for defining HTTP proxy via the $HTTP_PROXY (etc) env-var

### DIFF
--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -1,5 +1,5 @@
 class HttpConnectionOptions
-  attr_reader :host, :port, :tls, :proxy, :bind, :bind_port
+  attr_reader :host, :port, :tls, :bind, :bind_port
   attr_reader :connect_timeout, :inactivity_timeout
 
   def initialize(uri, options)
@@ -41,5 +41,20 @@ class HttpConnectionOptions
 
   def socks_proxy?
     @proxy && (@proxy[:type] == :socks5)
+  end
+
+  def proxy
+    @proxy ||= proxy_env_uri && { :host => proxy_env_uri.host, :port => proxy_env_uri.port, :type => :http }
+  end
+
+  def proxy_env_uri
+    # TODO: Add support for $http_no_proxy or $no_proxy ?
+    @proxy_env_uri ||= \
+      begin
+        proxy_str = @https ?
+          ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ENV['ALL_PROXY'] :
+          ENV['HTTP_PROXY'] || ENV['http_proxy'] || ENV['ALL_PROXY']
+        Addressable::URI::parse(proxy_str) if proxy_str
+      end
   end
 end

--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -22,7 +22,7 @@ class HttpConnectionOptions
     uri.port ||= (@https ? 443 : 80)
     @tls[:sni_hostname] = uri.host
 
-    if proxy = options[:proxy]
+    if proxy
       @host = proxy[:host]
       @port = proxy[:port]
     else

--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -53,7 +53,16 @@ class HttpConnectionOptions
                 # Fall-back to $ALL_PROXY if none of the above env-vars have values
                 end || ENV['ALL_PROXY']
 
+    # Addressable::URI::parse will return `nil` if given `nil` and an empty URL for an empty string
+    # so, let's short-circuit that:
+    return if !proxy_str || proxy_str.empty?
+
     proxy_env_uri = Addressable::URI::parse(proxy_str)
     { :host => proxy_env_uri.host, :port => proxy_env_uri.port, :type => :http }
+
+  rescue Addressable::URI::InvalidURIError
+    # An invalid env-var shouldn't crash the config step, IMHO.
+    # We should somehow log / warn about this, perhaps...
+    return
   end
 end

--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -1,5 +1,5 @@
 class HttpConnectionOptions
-  attr_reader :host, :port, :proxy, :tls, :bind, :bind_port
+  attr_reader :host, :port, :tls, :proxy, :bind, :bind_port
   attr_reader :connect_timeout, :inactivity_timeout
 
   def initialize(uri, options)

--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -7,7 +7,6 @@ class HttpConnectionOptions
     @inactivity_timeout  = options[:inactivity_timeout] ||= 10   # default connection inactivity (post-setup) timeout
 
     @tls   = options[:tls] || options[:ssl] || {}
-    @proxy = options[:proxy] || proxy_from_env
 
     if bind = options[:bind]
       @bind = bind[:host] || '0.0.0.0'
@@ -21,6 +20,8 @@ class HttpConnectionOptions
     @https = uri.scheme == "https"
     uri.port ||= (@https ? 443 : 80)
     @tls[:sni_hostname] = uri.host
+
+    @proxy = options[:proxy] || proxy_from_env
 
     if proxy
       @host = proxy[:host]

--- a/spec/dns_spec.rb
+++ b/spec/dns_spec.rb
@@ -7,7 +7,7 @@ describe EventMachine::HttpRequest do
       http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect/badhost', :connect_timeout => 0.1).get :redirects => 1
       http.callback { failed(http) }
       http.errback {
-        http.error.should match('unable to resolve server address')
+        http.error.should match(/unable to resolve (server |)address/)
         EventMachine.stop
       }
     }
@@ -31,7 +31,7 @@ describe EventMachine::HttpRequest do
       http = EventMachine::HttpRequest.new('http://somethinglocal/', :connect_timeout => 0.1).get
       http.callback { failed(http) }
       http.errback {
-        http.error.should match(/unable to resolve server address/)
+        http.error.should match(/unable to resolve (server |)address/)
         http.response_header.status.should == 0
         EventMachine.stop
       }

--- a/spec/http_proxy_spec.rb
+++ b/spec/http_proxy_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 shared_examples "*_PROXY var" do
   it "should use HTTP proxy" do
     EventMachine.run {
-      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/?q=test').get
+      http = EventMachine::HttpRequest.new("#{proxy_test_scheme}://127.0.0.1:8090/?q=test").get
 
       http.errback { failed(http) }
       http.callback {
@@ -121,44 +121,64 @@ describe EventMachine::HttpRequest do
       end
     end
 
-    context "with HTTP_PROXY env" do
-      before(:each) do
-        ENV['HTTP_PROXY'] = 'http://127.0.0.1:8083'
+    context "when parsing *_PROXY vars" do
+      context "with $HTTP_PROXY env" do
+        let(:proxy_test_scheme) { :http }
+
+        before(:all) do
+          PROXY_ENV_VARS.each {|k| ENV.delete k }
+          ENV['HTTP_PROXY'] = 'http://127.0.0.1:8083'
+        end
+
+        include_examples "*_PROXY var"
       end
 
-      include_examples "*_PROXY var"
-    end
+      context "with $http_proxy env" do
+        let(:proxy_test_scheme) { :http }
 
-    context "with http_proxy env" do
-      before(:each) do
-        ENV['http_proxy'] = 'http://127.0.0.1:8083'
+        before(:all) do
+          PROXY_ENV_VARS.each {|k| ENV.delete k }
+          ENV['http_proxy'] = 'http://127.0.0.1:8083'
+        end
+
+        include_examples "*_PROXY var"
       end
 
-      include_examples "*_PROXY var"
-    end
+      ## TODO: Use a Mongrel HTTP server that can handle SSL:
+      context "with $HTTPS_PROXY env", skip: "Mongrel isn't configured to handle HTTPS, currently" do
+        let(:proxy_test_scheme) { :https }
 
-    context "with HTTPS_PROXY env" do
-      before(:each) do
-        ENV['HTTPS_PROXY'] = 'http://127.0.0.1:8083'
+        before(:all) do
+          PROXY_ENV_VARS.each {|k| ENV.delete k }
+          ENV['HTTPS_PROXY'] = 'http://127.0.0.1:8083'
+        end
+
+        include_examples "*_PROXY var"
       end
 
-      include_examples "*_PROXY var"
-    end
+      ## TODO: Use a Mongrel HTTP server that can handle SSL:
+      context "with $https_proxy env", skip: "Mongrel isn't configured to handle HTTPS, currently" do
+        let(:proxy_test_scheme) { :https }
 
-    context "with https_proxy env" do
-      before(:each) do
-        ENV['https_proxy'] = 'http://127.0.0.1:8083'
+        before(:all) do
+          PROXY_ENV_VARS.each {|k| ENV.delete k }
+          ENV['https_proxy'] = 'http://127.0.0.1:8083'
+        end
+
+        include_examples "*_PROXY var"
       end
 
-      include_examples "*_PROXY var"
-    end
+      context "with $ALL_PROXY env" do
+        let(:proxy_test_scheme) { :http }
 
-    context "with ALL_PROXY env" do
-      before(:each) do
-        ENV['ALL_PROXY'] = 'http://127.0.0.1:8083'
+        before(:all) do
+          PROXY_ENV_VARS.each {|k| ENV.delete k }
+          ENV['ALL_PROXY'] = 'http://127.0.0.1:8083'
+        end
+
+        include_examples "*_PROXY var"
       end
-
-      include_examples "*_PROXY var"
     end
   end
+
 end

--- a/spec/http_proxy_spec.rb
+++ b/spec/http_proxy_spec.rb
@@ -1,107 +1,164 @@
 require 'helper'
 
+shared_examples "*_PROXY var" do
+  it "should use HTTP proxy" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/?q=test').get
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.response_header.should_not include("X_PROXY_AUTH")
+        http.response.should match('test')
+        EventMachine.stop
+      }
+    }
+  end
+end
+
 describe EventMachine::HttpRequest do
 
   context "connections via" do
-    let(:proxy) { {:proxy => { :host => '127.0.0.1', :port => 8083 }} }
-    let(:authenticated_proxy) { {:proxy => { :host => '127.0.0.1', :port => 8083, :authorization => ["user", "name"] } } }
+    context "without *_PROXY env" do
+      let(:proxy) { {:proxy => { :host => '127.0.0.1', :port => 8083 }} }
+      let(:authenticated_proxy) { {:proxy => { :host => '127.0.0.1', :port => 8083, :authorization => ["user", "name"] } } }
 
-    it "should use HTTP proxy" do
-      EventMachine.run {
-        http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/?q=test', proxy).get
+      it "should use HTTP proxy" do
+        EventMachine.run {
+          http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/?q=test', proxy).get
 
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          http.response_header.should_not include("X_PROXY_AUTH")
-          http.response.should match('test')
-          EventMachine.stop
+          http.errback { failed(http) }
+          http.callback {
+            http.response_header.status.should == 200
+            http.response_header.should_not include("X_PROXY_AUTH")
+            http.response.should match('test')
+            EventMachine.stop
+          }
         }
-      }
+      end
+
+      it "should use HTTP proxy with authentication" do
+        EventMachine.run {
+          http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/proxyauth?q=test', authenticated_proxy).get
+
+          http.errback { failed(http) }
+          http.callback {
+            http.response_header.status.should == 200
+            http.response_header['X_PROXY_AUTH'].should == "Proxy-Authorization: Basic dXNlcjpuYW1l"
+            http.response.should match('test')
+            EventMachine.stop
+          }
+        }
+      end
+
+      it "should send absolute URIs to the proxy server" do
+        EventMachine.run {
+
+          http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/?q=test', proxy).get
+
+          http.errback { failed(http) }
+          http.callback {
+            http.response_header.status.should == 200
+
+            # The test proxy server gives the requested uri back in this header
+            http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/?q=test'
+            http.response_header['X_THE_REQUESTED_URI'].should_not == '/?q=test'
+            http.response.should match('test')
+            EventMachine.stop
+          }
+        }
+      end
+
+      it "should strip basic auth from before the host in URI sent to proxy" do
+        EventMachine.run {
+
+          http = EventMachine::HttpRequest.new('http://user:pass@127.0.0.1:8090/echo_authorization_header', proxy).get
+
+          http.errback { failed(http) }
+          http.callback {
+            http.response_header.status.should == 200
+            # The test proxy server gives the requested uri back in this header
+            http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/echo_authorization_header'
+            # Ensure the basic auth was converted to a header correctly
+            http.response.should match('authorization:Basic dXNlcjpwYXNz')
+            EventMachine.stop
+          }
+        }
+      end
+
+      it "should include query parameters specified in the options" do
+        EventMachine.run {
+          http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/', proxy).get :query => { 'q' => 'test' }
+
+          http.errback { failed(http) }
+          http.callback {
+            http.response_header.status.should == 200
+            http.response.should match('test')
+            EventMachine.stop
+          }
+        }
+      end
+
+      it "should use HTTP proxy while redirecting" do
+        EventMachine.run {
+          http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect', proxy).get :redirects => 1
+
+          http.errback { failed(http) }
+          http.callback {
+            http.response_header.status.should == 200
+
+            http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/gzip'
+            http.response_header['X_THE_REQUESTED_URI'].should_not == '/redirect'
+
+            http.response_header["CONTENT_ENCODING"].should == "gzip"
+            http.response.should == "compressed"
+            http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
+            http.redirects.should == 1
+
+            EventMachine.stop
+          }
+        }
+      end
     end
 
-    it "should use HTTP proxy with authentication" do
-      EventMachine.run {
-        http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/proxyauth?q=test', authenticated_proxy).get
+    context "with HTTP_PROXY env" do
+      before(:each) do
+        ENV['HTTP_PROXY'] = 'http://127.0.0.1:8083'
+      end
 
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          http.response_header['X_PROXY_AUTH'].should == "Proxy-Authorization: Basic dXNlcjpuYW1l"
-          http.response.should match('test')
-          EventMachine.stop
-        }
-      }
+      include_examples "*_PROXY var"
     end
 
-    it "should send absolute URIs to the proxy server" do
-      EventMachine.run {
+    context "with http_proxy env" do
+      before(:each) do
+        ENV['http_proxy'] = 'http://127.0.0.1:8083'
+      end
 
-        http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/?q=test', proxy).get
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-
-          # The test proxy server gives the requested uri back in this header
-          http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/?q=test'
-          http.response_header['X_THE_REQUESTED_URI'].should_not == '/?q=test'
-          http.response.should match('test')
-          EventMachine.stop
-        }
-      }
+      include_examples "*_PROXY var"
     end
 
-    it "should strip basic auth from before the host in URI sent to proxy" do
-      EventMachine.run {
+    context "with HTTPS_PROXY env" do
+      before(:each) do
+        ENV['HTTPS_PROXY'] = 'http://127.0.0.1:8083'
+      end
 
-        http = EventMachine::HttpRequest.new('http://user:pass@127.0.0.1:8090/echo_authorization_header', proxy).get
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          # The test proxy server gives the requested uri back in this header
-          http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/echo_authorization_header'
-          # Ensure the basic auth was converted to a header correctly
-          http.response.should match('authorization:Basic dXNlcjpwYXNz')
-          EventMachine.stop
-        }
-      }
+      include_examples "*_PROXY var"
     end
 
-    it "should include query parameters specified in the options" do
-      EventMachine.run {
-        http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/', proxy).get :query => { 'q' => 'test' }
+    context "with https_proxy env" do
+      before(:each) do
+        ENV['https_proxy'] = 'http://127.0.0.1:8083'
+      end
 
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          http.response.should match('test')
-          EventMachine.stop
-        }
-      }
+      include_examples "*_PROXY var"
     end
 
-    it "should use HTTP proxy while redirecting" do
-      EventMachine.run {
-        http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/redirect', proxy).get :redirects => 1
+    context "with ALL_PROXY env" do
+      before(:each) do
+        ENV['ALL_PROXY'] = 'http://127.0.0.1:8083'
+      end
 
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-
-          http.response_header['X_THE_REQUESTED_URI'].should == 'http://127.0.0.1:8090/gzip'
-          http.response_header['X_THE_REQUESTED_URI'].should_not == '/redirect'
-
-          http.response_header["CONTENT_ENCODING"].should == "gzip"
-          http.response.should == "compressed"
-          http.last_effective_url.to_s.should == 'http://127.0.0.1:8090/gzip'
-          http.redirects.should == 1
-
-          EventMachine.stop
-        }
-      }
+      include_examples "*_PROXY var"
     end
   end
-
 end

--- a/spec/http_proxy_spec.rb
+++ b/spec/http_proxy_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-shared_examples "*_PROXY var" do
+shared_examples "*_PROXY var (through proxy)" do
   it "should use HTTP proxy" do
     EventMachine.run {
       http = EventMachine::HttpRequest.new("#{proxy_test_scheme}://127.0.0.1:8090/?q=test").get
@@ -121,7 +121,7 @@ describe EventMachine::HttpRequest do
       end
     end
 
-    context "when parsing *_PROXY vars" do
+    context "when parsing *_PROXY var (through proxy)s" do
       context "with $HTTP_PROXY env" do
         let(:proxy_test_scheme) { :http }
 
@@ -130,7 +130,7 @@ describe EventMachine::HttpRequest do
           ENV['HTTP_PROXY'] = 'http://127.0.0.1:8083'
         end
 
-        include_examples "*_PROXY var"
+        include_examples "*_PROXY var (through proxy)"
       end
 
       context "with $http_proxy env" do
@@ -141,7 +141,7 @@ describe EventMachine::HttpRequest do
           ENV['http_proxy'] = 'http://127.0.0.1:8083'
         end
 
-        include_examples "*_PROXY var"
+        include_examples "*_PROXY var (through proxy)"
       end
 
       ## TODO: Use a Mongrel HTTP server that can handle SSL:
@@ -153,7 +153,7 @@ describe EventMachine::HttpRequest do
           ENV['HTTPS_PROXY'] = 'http://127.0.0.1:8083'
         end
 
-        include_examples "*_PROXY var"
+        include_examples "*_PROXY var (through proxy)"
       end
 
       ## TODO: Use a Mongrel HTTP server that can handle SSL:
@@ -165,7 +165,7 @@ describe EventMachine::HttpRequest do
           ENV['https_proxy'] = 'http://127.0.0.1:8083'
         end
 
-        include_examples "*_PROXY var"
+        include_examples "*_PROXY var (through proxy)"
       end
 
       context "with $ALL_PROXY env" do
@@ -176,7 +176,7 @@ describe EventMachine::HttpRequest do
           ENV['ALL_PROXY'] = 'http://127.0.0.1:8083'
         end
 
-        include_examples "*_PROXY var"
+        include_examples "*_PROXY var (through proxy)"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,25 @@
+PROXY_ENV_VARS = %w[HTTP_PROXY http_proxy HTTPS_PROXY https_proxy ALL_PROXY]
+
 RSpec.configure do |config|
+  proxy_envs = {}
+
   config.mock_with :rspec do |c|
     c.syntax = [:should, :expect]
   end
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
+  end
+
+  config.before :all do
+    # Back-up ENV *_PROXY vars
+    orig_proxy_envs = Hash[
+      PROXY_ENV_VARS.select {|k| ENV.key? k }.map {|k| [k, ENV.delete(k)] }
+    ]
+    proxy_envs.replace(orig_proxy_envs)
+  end
+
+  config.after :all do
+    # Restore ENV *_PROXY vars
+    ENV.update(proxy_envs)
   end
 end


### PR DESCRIPTION
FIXES #306 

NB: The library may not correctly deal with SSE conversations if the Proxy is trying to buffer the data.
E.g. see http://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate