### PR TITLE
Add support for 'Expect: 100-continue' header

### DIFF
--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -199,7 +199,7 @@ module EventMachine
       @conn.send_data request_header
 
       @req_body = body || (@req.file && Pathname.new(@req.file))
-      send_request_body
+      send_request_body unless @req.headers['expect'] == '100-continue'
     end
 
     def on_body_data(data)
@@ -221,6 +221,10 @@ module EventMachine
       else
         @response << data
       end
+    end
+
+    def request_body_pending?
+      !!@req_body
     end
 
     def send_request_body

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -117,8 +117,13 @@ module EventMachine
       @p.header_value_type = :mixed
       @p.on_headers_complete = proc do |h|
         if client
-          client.parse_response_header(h, @p.http_version, @p.status_code)
-          :reset if client.req.no_body?
+          if @p.status_code == 100
+            client.send_request_body
+            @p.reset!
+          else
+            client.parse_response_header(h, @p.http_version, @p.status_code)
+            :reset if client.req.no_body?
+          end
         else
           # if we receive unexpected data without a pending client request
           # reset the parser to avoid firing any further callbacks and close
@@ -151,11 +156,7 @@ module EventMachine
 
     def receive_data(data)
       begin
-        if client.request_body_pending? && data.starts_with?('HTTP/1.1 100 Continue')
-          client.send_request_body
-        else
-          @p << data
-        end
+        @p << data
       rescue HTTP::Parser::Error => e
         c = @clients.shift
         c.nil? ? unbind(e.message) : c.on_error(e.message)

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -151,7 +151,11 @@ module EventMachine
 
     def receive_data(data)
       begin
-        @p << data
+        if client.request_body_pending? && data.starts_with?('HTTP/1.1 100 Continue')
+          client.send_request_body
+        else
+          @p << data
+        end
       rescue HTTP::Parser::Error => e
         c = @clients.shift
         c.nil? ? unbind(e.message) : c.on_error(e.message)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -256,6 +256,19 @@ describe EventMachine::HttpRequest do
     }
   end
 
+  xit "should support expect-continue header" do
+    EventMachine.run {
+      http = EventMachine::HttpRequest.new('http://127.0.0.1:8090').post :body => "data", :head => { 'expect' => '100-continue' }
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.response.should == "data"
+        EventMachine.stop
+      }
+    }
+  end
+
   it "should perform successful GET with custom header" do
     EventMachine.run {
       http = EventMachine::HttpRequest.new('http://127.0.0.1:8090/').get :head => {'if-none-match' => 'evar!'}


### PR DESCRIPTION
This is how I fixed #321, it could probably use some refactoring