### PR TITLE
Run test server with WEBrick instead of Mongrel

### DIFF
--- a/em-http-request.gemspec
+++ b/em-http-request.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'eventmachine', '>= 1.0.3'
   s.add_dependency 'http_parser.rb', '>= 0.6.0'
 
-  s.add_development_dependency 'mongrel', '~> 1.2.0.pre2'
   s.add_development_dependency 'multi_json'
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -817,7 +817,7 @@ describe EventMachine::HttpRequest do
       req.callback do
         req = conn.get
 
-        req.callback { failed(http) }
+        req.callback { fail }
         req.errback do
           req.error.should match('connection closed by server')
           EventMachine.stop

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -53,7 +53,7 @@ module Stallion
 
   def self.run(options = {})
     options = {:Host => "127.0.0.1", :Port => 8090}.merge(options)
-    Rack::Handler::Mongrel.run(Rack::Lint.new(self), options)
+    Rack::Handler::WEBrick.run(Rack::Lint.new(self), options)
   end
 
   def self.call(env)


### PR DESCRIPTION
(Mongrel is no longer supported with by Rack v2+)

Remaining test failures: 
```
  1) EventMachine::HttpRequest should set content-length to 0 on posts with empty bodies
     Failure/Error: http.response.strip.split(':')[1].should == '0'
       expected: "0"
            got: nil (using ==)
    
  2) EventMachine::HttpRequest should report error if connection was closed by server on client keepalive requests
     Failure/Error: req.callback { fail }
     RuntimeError:

  3) EventMachine::HttpRequest should fail gracefully on an invalid host in Location header
     Failure/Error: http.error.should match(/unable to resolve (server |)address/)
     
       expected "connection closed by server" to match /unable to resolve (server |)address/

  4) EventMachine::HttpRequest should keep default http port in redirect url that include it
     Failure/Error: http.last_effective_url.to_s.should == 'http://host:80/'
     
       expected: "http://host:80/"
            got: "http://host/" (using ==)

  5) EventMachine::HttpRequest should keep default https port in redirect url that include it
     Failure/Error: http.last_effective_url.to_s.should == 'https://host:443/'

       expected: "https://host:443/"
            got: "https://host/" (using ==)
```