### PR TITLE
Change conn.connopts.https when sheme changed when redirect

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -192,6 +192,7 @@ module EventMachine
           conn = HttpConnection.new
           client.conn = conn
           conn.connopts = @connopts
+          conn.connopts.https = new_location.scheme == "https"
           conn.uri = client.req.uri
           conn.activate_connection(client)
 

--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -1,6 +1,7 @@
 class HttpConnectionOptions
   attr_reader :host, :port, :tls, :proxy, :bind, :bind_port
   attr_reader :connect_timeout, :inactivity_timeout
+  attr_writer :https
 
   def initialize(uri, options)
     @connect_timeout     = options[:connect_timeout] || 5        # default connection setup timeout


### PR DESCRIPTION
When url scheme is changed when redirect (e. g. https -> http) https property of conn.connopts should be changed too. CONNECT method is used by default for https connections , when redirecting to http url, CONNECT method will be used too, because connopts is copied from previous connection. This behavior is wrong, because CONNECT method cant be used for http.