### PR TITLE
don't warn about TLS host verification when verify_peer is explicitly false

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -64,7 +64,7 @@ module EventMachine
     def ssl_handshake_completed
       unless verify_peer?
         warn "[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
-             " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details"
+             " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details" unless parent.connopts.tls.has_key?(:verify_peer)
         return true
       end
 

--- a/spec/ssl_spec.rb
+++ b/spec/ssl_spec.rb
@@ -38,6 +38,34 @@ requires_connection do
           }
         }
       end
+
+      it "should not warn if verify_peer is true" do
+        EventMachine.run {
+          http = EventMachine::HttpRequest.new('https://mail.google.com:443/mail', {tls: {verify_peer: true}}).get
+
+          http.callback {
+            $stderr.rewind
+            $stderr.string.chomp.should_not eq("[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
+                                               " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details")
+
+            EventMachine.stop
+          }
+        }
+      end
+
+      it "should warn if verify_peer is unspecified" do
+        EventMachine.run {
+          http = EventMachine::HttpRequest.new('https://mail.google.com:443/mail').get
+
+          http.callback {
+            $stderr.rewind
+            $stderr.string.chomp.should eq("[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
+                                           " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details")
+
+            EventMachine.stop
+          }
+        }
+      end
     end
   end
 

--- a/spec/ssl_spec.rb
+++ b/spec/ssl_spec.rb
@@ -17,6 +17,8 @@ requires_connection do
 
     describe "TLS hostname verification" do
       before do
+        @cve_warning = "[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
+                       " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details"
         @orig_stderr = $stderr
         $stderr = StringIO.new
       end
@@ -31,8 +33,7 @@ requires_connection do
 
           http.callback {
             $stderr.rewind
-            $stderr.string.chomp.should_not eq("[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
-                                               " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details")
+            $stderr.string.chomp.should_not eq(@cve_warning)
 
             EventMachine.stop
           }
@@ -45,8 +46,7 @@ requires_connection do
 
           http.callback {
             $stderr.rewind
-            $stderr.string.chomp.should_not eq("[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
-                                               " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details")
+            $stderr.string.chomp.should_not eq(@cve_warning)
 
             EventMachine.stop
           }
@@ -59,8 +59,7 @@ requires_connection do
 
           http.callback {
             $stderr.rewind
-            $stderr.string.chomp.should eq("[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
-                                           " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details")
+            $stderr.string.chomp.should eq(@cve_warning)
 
             EventMachine.stop
           }


### PR DESCRIPTION
Let me know if you think the tests are overkill.