### PR TITLE
Use explicit keyword argument in stallion.rb

### DIFF
--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -53,7 +53,13 @@ module Stallion
 
   def self.run(options = {})
     options = {:Host => "127.0.0.1", :Port => 8090}.merge(options)
-    Rack::Handler::Mongrel.run(Rack::Lint.new(self), options)
+
+    ruby_version = RUBY_VERSION.split('.').map(&:to_i)
+    if ruby_version[0] >= 3
+      Rack::Handler::Mongrel.run(Rack::Lint.new(self), **options)
+    else
+      Rack::Handler::Mongrel.run(Rack::Lint.new(self), options)
+    end
   end
 
   def self.call(env)


### PR DESCRIPTION
Since ruby 3.0 the keyword argument needs to be explicitly declared.

Relevant Ruby issue: https://bugs.ruby-lang.org/issues/14183