### PR TITLE
Fix. the issue #346 on igrigorik/em-http-request

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -174,7 +174,6 @@ module EventMachine
       @pending = []
 
       @p = Http::Parser.new
-      @p.header_value_type = :mixed
       @p.on_headers_complete = proc do |h|
         if client
           if @p.status_code == 100


### PR DESCRIPTION
i had to apply this modify to fix the problem of the #346 issue.

with jruby 9.2 and http_parser.rb v0.6.0, thats instructions fails.

@p = Http::Parser.new
**@p.header_value_type = :mixed**

I think that the parser has a default header_value_type as "mixed" and is unnecessary the explicit assigment