### PR TITLE
Bug fix: peer verification fails when using TLS over an HTTP proxy

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -57,7 +57,7 @@ module EventMachine
         end
         true
       else
-        raise OpenSSL::SSL::SSLError.new(%(unable to verify the server certificate for "#{host}"))
+        raise OpenSSL::SSL::SSLError.new(%(unable to verify the server certificate for "#{sni_hostname}"))
       end
     end
 
@@ -68,8 +68,8 @@ module EventMachine
         return true
       end
 
-      unless OpenSSL::SSL.verify_certificate_identity(@last_seen_cert, host)
-        raise OpenSSL::SSL::SSLError.new(%(host "#{host}" does not match the server certificate))
+      unless OpenSSL::SSL.verify_certificate_identity(@last_seen_cert, sni_hostname)
+        raise OpenSSL::SSL::SSLError.new(%(host "#{sni_hostname}" does not match the server certificate))
       else
         true
       end
@@ -81,6 +81,10 @@ module EventMachine
 
     def host
       parent.connopts.host
+    end
+
+    def sni_hostname
+      parent.connopts.tls[:sni_hostname]
     end
 
     def certificate_store


### PR DESCRIPTION
When tunneling a TLS connection through an HTTP proxy the hostname of the proxy server is incorrectly used for peer verification. As-is the following error will be raised:
```
em-http-request-1.1.7/lib/em-http/http_connection.rb:72:in `ssl_handshake_completed': host "some.proxy.server.tld" does not match the server certificate (OpenSSL::SSL::SSLError)
```

It seems that this is because `connopts.host` [will always contain the proxy hostname when a proxy is configured](https://github.com/igrigorik/em-http-request/blob/master/lib/em-http/http_connection_options.rb#L28) and is unconditionally used for peer verification.

The resolution suggested in this PR is instead using `@tls[:sni_hostname]` which will [contain the correct downstream hostname](https://github.com/igrigorik/em-http-request/blob/master/lib/em-http/http_connection_options.rb#L23). 