### PR TITLE
Fix for LetsEncrypt root expiry

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -55,10 +55,9 @@ module EventMachine
         rescue OpenSSL::X509::StoreError => e
           raise e unless e.message == 'cert already in hash table'
         end
-        true
-      else
-        raise OpenSSL::SSL::SSLError.new(%(unable to verify the server certificate for "#{host}"))
       end
+
+      true
     end
 
     def ssl_handshake_completed
@@ -68,7 +67,8 @@ module EventMachine
         return true
       end
 
-      unless OpenSSL::SSL.verify_certificate_identity(@last_seen_cert, host)
+      unless certificate_store.verify(@last_seen_cert) &&
+             OpenSSL::SSL.verify_certificate_identity(@last_seen_cert, host)
         raise OpenSSL::SSL::SSLError.new(%(host "#{host}" does not match the server certificate))
       else
         true


### PR DESCRIPTION
Every LetsEncrypt issued signature chain now starts with an expired certificate,
but the second item in the chain is a trusted root.  So instead of failing the
whole validation for any link in the chain failing, just don't add failed links
to the store, then make sure the final certificate is valid given whatever *was*
added to the store.