### PR TITLE
Add support for NO_PROXY env variable

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-PROXY_ENV_VARS = %w[HTTP_PROXY http_proxy HTTPS_PROXY https_proxy ALL_PROXY]
+PROXY_ENV_VARS = %w[HTTP_PROXY http_proxy HTTPS_PROXY https_proxy ALL_PROXY NO_PROXY no_proxy].freeze
 
 RSpec.configure do |config|
   proxy_envs = {}


### PR DESCRIPTION
Implement missing feature, marked with this comment in `http_connection_options.rb`:
```
 # TODO: Add support for $http_no_proxy or $no_proxy ?
```

---

Set env variable `no_proxy` or `NO_PROXY` to provide coma-separated list of hosts for which env-provided `HTTP_PROXY` should not be used.

Domain *wildcards* are supported. For example: `.tld` will match any host name ending with `.tld`.

Example use:
```
HTTP_PROXY=http://host:8181 \
HTTPS_PROXY=http://host:8181 \
NO_PROXY=service1,.anything.in.subdomain,service2.internal \
bundle exec ruby my-app-with-em-http-request.rb
```