### PR TITLE
Also stop the HTTP parser in addition to resetting it.

### DIFF
--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -190,6 +190,7 @@ module EventMachine
           # the connection because we're processing invalid HTTP
           @p.reset!
           unbind
+          :stop
         end
       end
 


### PR DESCRIPTION
The behavior was depending on an exception raised later after resetting the parser and then this resulting in parser not calling any further callback. With http_parser.rb >= 0.6.1 this is no longer true.

Stopping the parser at this point seems correct as it also stops firing additional callbacks from being called.

This solution seems to be OK for http_parser.rb 0.6.0 and 0.8.0 (and I'd guess versions in between) as no new test fails with this fix.

Fixes failure in test suite:
```
Failure/Error: if !client.continue?
     NoMethodError:
       undefined method `continue?' for nil:NilClass
```
From `EventMachine::HttpRequest should close connection on invalid HTTP response'.