### PR TITLE
Fix failing specs and replace TravisCI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    name: "RSpec / Ruby ${{ matrix.ruby }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          [
+            "2.2",
+            "2.3",
+            "2.4",
+            "2.5",
+            "2.6",
+            "2.7",
+            "3.0",
+            "3.1",
+            "3.2"
+          ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,13 @@ on:
     branches:
       - master
 jobs:
-  test:
+  spec:
     name: "RSpec / Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
           [
-            "2.2",
             "2.3",
             "2.4",
             "2.5",
@@ -29,3 +28,14 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake spec
+  spec-legacy:
+    name: "RSpec / Ruby 2.2"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.2
+          bundler-cache: true
+      - name: rake spec
+        run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.4
-script: bundle exec rake spec
-notifications:
-  email:
-    - ilya@igvita.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EM-HTTP-Request 
 
-[![Gem Version](https://badge.fury.io/rb/em-http-request.svg)](http://rubygems.org/gems/em-http-request) [![Build Status](https://travis-ci.org/igrigorik/em-http-request.svg)](https://travis-ci.org/igrigorik/em-http-request)
+[![Gem Version](https://badge.fury.io/rb/em-http-request.svg)](http://rubygems.org/gems/em-http-request)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/igrigorik/em-http-request/ci.yml)](https://github.com/igrigorik/em-http-request/actions/workflows/ci.yml)
 
 Async (EventMachine) HTTP client, with support for:
 

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -190,6 +190,7 @@ module EventMachine
           # the connection because we're processing invalid HTTP
           @p.reset!
           unbind
+          :stop
         end
       end
 
@@ -198,7 +199,7 @@ module EventMachine
       end
 
       @p.on_message_complete = proc do
-        if client && !client.continue?
+        if !client.continue?
           c = @clients.shift
           c.state = :finished
           c.on_request_complete

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -198,7 +198,7 @@ module EventMachine
       end
 
       @p.on_message_complete = proc do
-        if !client.continue?
+        if client && !client.continue?
           c = @clients.shift
           c.state = :finished
           c.on_request_complete

--- a/spec/external_spec.rb
+++ b/spec/external_spec.rb
@@ -80,11 +80,10 @@ requires_connection do
     end
 
     it "should detect deflate encoding" do
-      # pending "need an endpoint which supports deflate.. MSN is no longer"
       EventMachine.run {
 
         options = {:head => {"accept-encoding" => "deflate"}, :redirects => 5}
-        http = EventMachine::HttpRequest.new('http://www.libpng.org/').get options
+        http = EventMachine::HttpRequest.new('https://www.bing.com/').get options
 
         http.errback { failed(http) }
         http.callback {

--- a/spec/ssl_spec.rb
+++ b/spec/ssl_spec.rb
@@ -9,7 +9,7 @@ requires_connection do
 
         http.errback { failed(http) }
         http.callback {
-          http.response_header.status.should == 302
+          http.response_header.status.should == 301
           EventMachine.stop
         }
       }


### PR DESCRIPTION
Three specs were failing on the `master` branch. This PR fixes all three specs.

Furthermore, this repo currently had no CI coverage because Travis builds were no longer running. To fix this, this PR removes the Travis config and switches to a GitHub Actions workflow for CI.

The Travis config only tested Ruby 2.2; the new GitHub Actions workflow tests Ruby 2.2 through 3.2.