### PR TITLE
Use cookiejar2 instead of cookiejar to support Ruby 3.3

### DIFF
--- a/em-http-request.gemspec
+++ b/em-http-request.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'em-http-request'
 
   s.add_dependency 'addressable', '>= 2.3.4'
-  s.add_dependency 'cookiejar', '!= 0.3.1'
+  s.add_dependency 'cookiejar2', '~> 0.3.5.1'
   s.add_dependency 'em-socksify', '>= 0.3'
   s.add_dependency 'eventmachine', '>= 1.0.3'
   s.add_dependency 'http_parser.rb', '>= 0.6.0'


### PR DESCRIPTION
Fixes #354 

`Regexp::new` with 3 arguments is deprecated and fails on Ruby 3.3. The cookiejar gem repo has been archived, so let's use a new one.