### PR TITLE
Fix GitHub Actions failures and add Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.2
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     steps:
+      - run: sudo apt-get install libcurl4-openssl-dev
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
@@ -22,6 +23,7 @@ jobs:
     name: "RSpec / Ruby 2.2"
     runs-on: ubuntu-20.04
     steps:
+      - run: sudo apt-get install libcurl4-openssl-dev
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     name: "RSpec / Ruby ${{ matrix.ruby }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby:
-          [
-            "2.3",
-            "2.4",
-            "2.5",
-            "2.6",
-            "2.7",
-            "3.0",
-            "3.1",
-            "3.2"
-          ]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
My initial GitHub Actions CI workflow that I provided in #357 had mistakes that are currently causing it to [fail](https://github.com/igrigorik/em-http-request/actions/runs/7405077029) on the master branch.

This PR fixes those failures. I have tested it on my fork, see: https://github.com/mattbrictson/em-http-request/actions/runs/7411502617

The following problems are now fixed:

- Fixed a `- uses` typo
- Install `libcurl4-openssl-dev` dependency so that the `curb` gem builds
- Set `fail-fast: false` so that one failing Ruby version in the CI matrix doesn't stop the others from running

I also added Ruby 3.3 to the build matrix. ~~Note that this version currently fails, due to known issues documented in #358.~~ Now fixed.