### PR TITLE
cookiejar is incompatible with Ruby HEAD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head"]
     steps:
       - run: sudo apt-get install libcurl4-openssl-dev
       - uses: actions/checkout@v4

--- a/lib/em-http/client.rb
+++ b/lib/em-http/client.rb
@@ -1,3 +1,9 @@
+require 'uri'
+
+if !defined?(URI::REGEXP::PATTERN)
+  URI.parser = URI::RFC2396_PARSER
+end
+
 require 'cookiejar'
 
 module EventMachine


### PR DESCRIPTION
EM-HTTP-Request depends on [cookiejar](https://github.com/dwaite/cookiejar) which is incompatible with Ruby HEAD due to [recent changes](https://github.com/ruby/ruby/commit/08e449d89baf1aeee87f084e1cd55bfe3b9cc46a) in the URI module in Ruby core.

cookiejar is EOL'd, so it should probably be replaced with a different library. This PR implements an ugly workaround. It is not intended to be merged but just illustrates the problem and acts as a placeholder for the general issue.