### PR TITLE
Prevent header injection attacks

### DIFF
--- a/lib/em-http/http_connection_options.rb
+++ b/lib/em-http/http_connection_options.rb
@@ -18,6 +18,7 @@ class HttpConnectionOptions
     end
 
     uri = uri.kind_of?(Addressable::URI) ? uri : Addressable::URI::parse(uri.to_s)
+    raise Addressable::URI::InvalidURIError if uri.to_s =~ /\s/
     @https = uri.scheme == "https"
     uri.port ||= (@https ? 443 : 80)
     @tls[:sni_hostname] = uri.hostname

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -50,10 +50,40 @@ describe EventMachine::HttpRequest do
   it "should raise error on invalid URL" do
     EventMachine.run {
       lambda {
-      EventMachine::HttpRequest.new('random?text').get
-    }.should raise_error(Addressable::URI::InvalidURIError)
+        EventMachine::HttpRequest.new('random?text').get
+      }.should raise_error(Addressable::URI::InvalidURIError)
 
-    EM.stop
+      EM.stop
+    }
+  end
+
+  it "should raise error on invalid URL containing spaces in path" do
+    EventMachine.run {
+      lambda {
+        EventMachine::HttpRequest.new('http://127.0.0.1:8090/path with space').get
+      }.should raise_error(Addressable::URI::InvalidURIError)
+
+      EM.stop
+    }
+  end
+
+  it "should raise error on invalid URL containing newlines in path" do
+    EventMachine.run {
+      lambda {
+        EventMachine::HttpRequest.new("http://127.0.0.1:8090/path\nwith\nnewlines").get
+      }.should raise_error(Addressable::URI::InvalidURIError)
+
+      EM.stop
+    }
+  end
+
+  it "should raise error on invalid URL containing spaces in query" do
+    EventMachine.run {
+      lambda {
+        EventMachine::HttpRequest.new('http://127.0.0.1:8090/?query=with space').get
+      }.should raise_error(Addressable::URI::InvalidURIError)
+
+      EM.stop
     }
   end
 


### PR DESCRIPTION
Add a safeguard against [header injection attacks](https://en.wikipedia.org/wiki/HTTP_header_injection).

There is no bug in em-http-request as such, but this patch removes an attack vector when the library is used to fetch user-provided URLs which have not been properly validated.

This suggestion is inspired by true events. 