### PR TITLE
Add Ruby 3.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
     steps:
       - run: sudo apt-get install libcurl4-openssl-dev
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds Ruby 3.4 to GitHub Actions CI.