### PR TITLE
Compatibility with Rack 3

### DIFF
--- a/benchmarks/server.rb
+++ b/benchmarks/server.rb
@@ -15,7 +15,7 @@ module Benchmark
   class Server < Sinatra::Base
 
     def self.run
-      Rack::Handler::WEBrick.run(
+      Rackup::Handler.get('webrick').run(
         Benchmark::Server.new,
         :Port => 9292,
         :AccessLog => [],

--- a/em-http-request.gemspec
+++ b/em-http-request.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'eventmachine', '>= 1.0.3'
   s.add_dependency 'http_parser.rb', '>= 0.6.0'
 
-  s.add_development_dependency 'mongrel', '~> 1.2.0.pre2'
+  s.add_development_dependency 'webrick'
   s.add_development_dependency 'multi_json'
-  s.add_development_dependency 'rack', '< 2.0'
+  s.add_development_dependency 'rack'
+  s.add_development_dependency 'rackup'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
 

--- a/spec/stallion.rb
+++ b/spec/stallion.rb
@@ -4,6 +4,7 @@
 # #--
 
 require 'rack'
+require 'rackup/handler'
 
 module Stallion
   class Mount
@@ -16,7 +17,7 @@ module Stallion
     end
 
     def match?(request)
-      method = request['REQUEST_METHOD']
+      method = request.env['REQUEST_METHOD']
       @methods.empty? or @methods.include?(method)
     end
   end
@@ -56,9 +57,9 @@ module Stallion
 
     ruby_version = RUBY_VERSION.split('.').map(&:to_i)
     if ruby_version[0] >= 3
-      Rack::Handler::Mongrel.run(Rack::Lint.new(self), **options)
+      Rackup::Handler.default.run(Rack::Lint.new(self), **options)
     else
-      Rack::Handler::Mongrel.run(Rack::Lint.new(self), options)
+      Rackup::Handler.default.run(Rack::Lint.new(self), options)
     end
   end
 


### PR DESCRIPTION
* Rack has removed Mongrel support ages ago [[1]]
* Rack split the webserver handlers into Rackup [[2]]

[1]: https://github.com/rack/rack/pull/870/commits/2577f0bb09ff85fe6b07d290f708028aebf640ee
[2]: https://github.com/rack/rack/pull/1937/commits/91c9c7f287f9f314e1523337b83d1b9c2c289f66